### PR TITLE
Updated dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id "com.github.ben-manes.versions" version "0.28.0"
-    id "com.diffplug.gradle.spotless" version "3.28.0"
+    id "com.diffplug.gradle.spotless" version "3.28.1"
 }
 
 
@@ -18,15 +18,14 @@ repositories {
 
 dependencies {
     compile 'io.reactivex.rxjava2:rxjava:2.2.18'
-    compile 'com.squareup.okhttp3:okhttp:4.4.1'
-    compile 'com.squareup.retrofit2:retrofit:2.7.2'
-    compile 'com.squareup.retrofit2:converter-gson:2.7.2'
-    compile 'com.squareup.okhttp3:logging-interceptor:4.4.1'
+    compile 'com.squareup.okhttp3:okhttp:4.5.0'
+    compile 'com.squareup.okhttp3:logging-interceptor:4.5.0'
+    compile 'com.squareup.retrofit2:retrofit:2.8.1'
+    compile 'com.squareup.retrofit2:converter-gson:2.8.1'
     compile 'joda-time:joda-time:2.10.5'
     compile 'org.joda:joda-money:1.0.1'
-    compile 'org.threeten:threetenbp:1.4.1'
     compile 'org.json:json:20190722'
-    compile 'com.google.code.gson:gson:2.8.6'
+    compile 'com.google.code.gson:gson:2.2.19'
     compile 'com.google.code.findbugs:jsr305:3.0.2'
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.junit.contrib:junit-theories:5.0-alpha-3'
@@ -35,7 +34,7 @@ dependencies {
     testImplementation 'org.slf4j:slf4j-simple:2.0.0-alpha1'
     testImplementation 'com.google.guava:guava:28.2-jre'
     testImplementation 'it.ozimov:java7-hamcrest-matchers:1.3.0'
-    testImplementation 'org.mockito:mockito-core:3.3.1'
+    testImplementation 'org.mockito:mockito-core:3.3.3'
     testImplementation 'com.google.zxing:core:3.4.0'
     testImplementation 'com.google.zxing:javase:3.4.0'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Fri Mar 13 18:00:39 JST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/java/com/univapay/sdk/adapters/JsonAdapters.java
+++ b/src/main/java/com/univapay/sdk/adapters/JsonAdapters.java
@@ -31,6 +31,8 @@ import com.univapay.sdk.types.Gateway;
 import com.univapay.sdk.types.MetadataMap;
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.time.Duration;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Map;
@@ -38,8 +40,6 @@ import org.joda.time.LocalDate;
 import org.joda.time.Period;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
-import org.threeten.bp.Duration;
-import org.threeten.bp.ZoneId;
 
 public class JsonAdapters {
 

--- a/src/main/java/com/univapay/sdk/builders/store/AbstractStoreBuilders.java
+++ b/src/main/java/com/univapay/sdk/builders/store/AbstractStoreBuilders.java
@@ -25,9 +25,9 @@ import com.univapay.sdk.types.CardBrand;
 import com.univapay.sdk.types.Country;
 import java.math.BigDecimal;
 import java.net.URL;
+import java.time.ZoneId;
 import java.util.Locale;
 import java.util.Map;
-import org.threeten.bp.ZoneId;
 import retrofit2.Retrofit;
 
 public abstract class AbstractStoreBuilders {

--- a/src/main/java/com/univapay/sdk/builders/subscription/AbstractSubscriptionBuilders.java
+++ b/src/main/java/com/univapay/sdk/builders/subscription/AbstractSubscriptionBuilders.java
@@ -28,10 +28,10 @@ import com.univapay.sdk.types.SubscriptionPeriod;
 import com.univapay.sdk.types.SubscriptionStatus;
 import com.univapay.sdk.utils.MetadataAdapter;
 import java.math.BigInteger;
+import java.time.Duration;
+import java.time.ZoneId;
 import java.util.Date;
 import org.joda.time.LocalDate;
-import org.threeten.bp.Duration;
-import org.threeten.bp.ZoneId;
 import retrofit2.Retrofit;
 
 public abstract class AbstractSubscriptionBuilders {

--- a/src/main/java/com/univapay/sdk/models/common/stores/LimitChargeByCardConfiguration.java
+++ b/src/main/java/com/univapay/sdk/models/common/stores/LimitChargeByCardConfiguration.java
@@ -1,7 +1,7 @@
 package com.univapay.sdk.models.common.stores;
 
 import com.google.gson.annotations.SerializedName;
-import org.threeten.bp.Duration;
+import java.time.Duration;
 
 public class LimitChargeByCardConfiguration {
   @SerializedName("quantity_of_charges")

--- a/src/main/java/com/univapay/sdk/models/request/configuration/ConfigurationRequest.java
+++ b/src/main/java/com/univapay/sdk/models/request/configuration/ConfigurationRequest.java
@@ -18,11 +18,11 @@ import com.univapay.sdk.types.CardBrand;
 import com.univapay.sdk.types.Country;
 import java.math.BigDecimal;
 import java.net.URL;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.threeten.bp.ZoneId;
 
 public class ConfigurationRequest {
 

--- a/src/main/java/com/univapay/sdk/models/request/configuration/StoreConfigurationRequest.java
+++ b/src/main/java/com/univapay/sdk/models/request/configuration/StoreConfigurationRequest.java
@@ -17,11 +17,11 @@ import com.univapay.sdk.types.CardBrand;
 import com.univapay.sdk.types.Country;
 import java.math.BigDecimal;
 import java.net.URL;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.threeten.bp.ZoneId;
 
 public class StoreConfigurationRequest extends ConfigurationRequest {
 

--- a/src/main/java/com/univapay/sdk/models/request/merchant/MerchantConfigurationRequest.java
+++ b/src/main/java/com/univapay/sdk/models/request/merchant/MerchantConfigurationRequest.java
@@ -19,11 +19,11 @@ import com.univapay.sdk.types.CardBrand;
 import com.univapay.sdk.types.Country;
 import java.math.BigDecimal;
 import java.net.URL;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.threeten.bp.ZoneId;
 
 public class MerchantConfigurationRequest extends ConfigurationRequest {
 

--- a/src/main/java/com/univapay/sdk/models/request/subscription/SubscriptionCreateData.java
+++ b/src/main/java/com/univapay/sdk/models/request/subscription/SubscriptionCreateData.java
@@ -7,8 +7,8 @@ import com.univapay.sdk.models.response.subscription.ScheduleSettings;
 import com.univapay.sdk.types.MetadataMap;
 import com.univapay.sdk.types.SubscriptionPeriod;
 import java.math.BigInteger;
+import java.time.Duration;
 import java.util.Date;
-import org.threeten.bp.Duration;
 
 public class SubscriptionCreateData extends SubscriptionRequestData {
 

--- a/src/main/java/com/univapay/sdk/models/response/configuration/Configuration.java
+++ b/src/main/java/com/univapay/sdk/models/response/configuration/Configuration.java
@@ -19,11 +19,11 @@ import com.univapay.sdk.types.CardBrand;
 import com.univapay.sdk.types.Country;
 import java.math.BigDecimal;
 import java.net.URL;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.threeten.bp.ZoneId;
 
 public class Configuration {
 

--- a/src/main/java/com/univapay/sdk/models/response/merchant/MerchantConfiguration.java
+++ b/src/main/java/com/univapay/sdk/models/response/merchant/MerchantConfiguration.java
@@ -19,11 +19,11 @@ import com.univapay.sdk.types.CardBrand;
 import com.univapay.sdk.types.Country;
 import java.math.BigDecimal;
 import java.net.URL;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.threeten.bp.ZoneId;
 
 public class MerchantConfiguration extends Configuration {
 

--- a/src/main/java/com/univapay/sdk/models/response/store/StoreConfiguration.java
+++ b/src/main/java/com/univapay/sdk/models/response/store/StoreConfiguration.java
@@ -16,11 +16,11 @@ import com.univapay.sdk.types.CardBrand;
 import com.univapay.sdk.types.Country;
 import java.math.BigDecimal;
 import java.net.URL;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.threeten.bp.ZoneId;
 
 public class StoreConfiguration extends Configuration {
   public StoreConfiguration(

--- a/src/main/java/com/univapay/sdk/models/response/subscription/ScheduleSettings.java
+++ b/src/main/java/com/univapay/sdk/models/response/subscription/ScheduleSettings.java
@@ -1,8 +1,8 @@
 package com.univapay.sdk.models.response.subscription;
 
 import com.google.gson.annotations.SerializedName;
+import java.time.ZoneId;
 import org.joda.time.LocalDate;
-import org.threeten.bp.ZoneId;
 
 public class ScheduleSettings {
 

--- a/src/main/java/com/univapay/sdk/models/response/subscription/ScheduledPayment.java
+++ b/src/main/java/com/univapay/sdk/models/response/subscription/ScheduledPayment.java
@@ -6,10 +6,10 @@ import com.univapay.sdk.models.response.SimpleModel;
 import com.univapay.sdk.models.response.UnivapayResponse;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.UUID;
 import org.joda.time.LocalDate;
-import org.threeten.bp.ZoneId;
 
 public class ScheduledPayment extends UnivapayResponse implements SimpleModel<ScheduledPaymentId> {
 

--- a/src/main/java/com/univapay/sdk/models/response/subscription/SimulatedPayment.java
+++ b/src/main/java/com/univapay/sdk/models/response/subscription/SimulatedPayment.java
@@ -2,8 +2,8 @@ package com.univapay.sdk.models.response.subscription;
 
 import com.google.gson.annotations.SerializedName;
 import java.math.BigInteger;
+import java.time.ZoneId;
 import org.joda.time.LocalDate;
-import org.threeten.bp.ZoneId;
 
 public class SimulatedPayment {
 

--- a/src/main/java/com/univapay/sdk/models/response/subscription/Subscription.java
+++ b/src/main/java/com/univapay/sdk/models/response/subscription/Subscription.java
@@ -12,9 +12,9 @@ import com.univapay.sdk.types.SubscriptionStatus;
 import com.univapay.sdk.utils.MetadataAdapter;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Duration;
 import java.util.Date;
 import java.util.UUID;
-import org.threeten.bp.Duration;
 
 public class Subscription extends UnivapayResponse implements SimpleModel<SubscriptionId> {
   @SerializedName("id")

--- a/src/main/java/com/univapay/sdk/utils/RequestUtils.java
+++ b/src/main/java/com/univapay/sdk/utils/RequestUtils.java
@@ -24,12 +24,12 @@ import com.univapay.sdk.types.CardBrand;
 import com.univapay.sdk.types.Country;
 import com.univapay.sdk.types.DayOfMonth;
 import com.univapay.sdk.types.MetadataMap;
+import java.time.Duration;
+import java.time.ZoneId;
 import java.util.Date;
 import okhttp3.ConnectionPool;
 import org.joda.time.LocalDate;
 import org.joda.time.Period;
-import org.threeten.bp.Duration;
-import org.threeten.bp.ZoneId;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 

--- a/src/main/java/com/univapay/sdk/utils/UnivapayCall.java
+++ b/src/main/java/com/univapay/sdk/utils/UnivapayCall.java
@@ -3,11 +3,13 @@ package com.univapay.sdk.utils;
 import java.io.IOException;
 import okhttp3.Headers;
 import okhttp3.Request;
+import okio.Timeout;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
 
 public class UnivapayCall<T> implements Call<T> {
+
   private Call<T> call;
   private boolean callbackFired;
   private okhttp3.Headers headers;
@@ -79,6 +81,11 @@ public class UnivapayCall<T> implements Call<T> {
   @Override
   public Request request() {
     return call.request();
+  }
+
+  @Override
+  public Timeout timeout() {
+    return call.timeout();
   }
 
   public boolean isCallbackFired() {

--- a/src/main/java/com/univapay/sdk/utils/builders/ConfigurationBuilder.java
+++ b/src/main/java/com/univapay/sdk/utils/builders/ConfigurationBuilder.java
@@ -19,10 +19,10 @@ import com.univapay.sdk.types.CardBrand;
 import com.univapay.sdk.types.Country;
 import java.math.BigDecimal;
 import java.net.URL;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import org.threeten.bp.ZoneId;
 
 public class ConfigurationBuilder<T extends ConfigurationRequest> implements Builder<T> {
   private BigDecimal percentFee;

--- a/src/test/java/com/univapay/sdk/configuration/ConfigurationTest.java
+++ b/src/test/java/com/univapay/sdk/configuration/ConfigurationTest.java
@@ -23,6 +23,8 @@ import com.univapay.sdk.utils.RequestUtils;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URL;
+import java.time.Duration;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -30,8 +32,6 @@ import java.util.Locale;
 import org.hamcrest.core.Is;
 import org.joda.time.Period;
 import org.junit.Test;
-import org.threeten.bp.Duration;
-import org.threeten.bp.ZoneId;
 
 public class ConfigurationTest {
 

--- a/src/test/java/com/univapay/sdk/merchant/GetMeTest.java
+++ b/src/test/java/com/univapay/sdk/merchant/GetMeTest.java
@@ -27,6 +27,8 @@ import com.univapay.sdk.utils.mockcontent.MerchantsFakeRR;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URL;
+import java.time.Duration;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -34,8 +36,6 @@ import java.util.Locale;
 import org.hamcrest.core.Is;
 import org.joda.time.Period;
 import org.junit.Test;
-import org.threeten.bp.Duration;
-import org.threeten.bp.ZoneId;
 
 public class GetMeTest extends GenericTest {
 

--- a/src/test/java/com/univapay/sdk/store/CreateStoreTest.java
+++ b/src/test/java/com/univapay/sdk/store/CreateStoreTest.java
@@ -33,11 +33,11 @@ import java.math.BigInteger;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.ParseException;
+import java.time.ZoneId;
 import java.util.*;
 import org.joda.time.Period;
 import org.junit.Assert;
 import org.junit.Test;
-import org.threeten.bp.ZoneId;
 
 public class CreateStoreTest extends GenericTest {
 

--- a/src/test/java/com/univapay/sdk/store/UpdateStoreTest.java
+++ b/src/test/java/com/univapay/sdk/store/UpdateStoreTest.java
@@ -33,10 +33,10 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.ZoneId;
 import java.util.*;
 import org.joda.time.Period;
 import org.junit.Test;
-import org.threeten.bp.ZoneId;
 
 public class UpdateStoreTest extends GenericTest {
 

--- a/src/test/java/com/univapay/sdk/subscription/CreateSubscriptionTest.java
+++ b/src/test/java/com/univapay/sdk/subscription/CreateSubscriptionTest.java
@@ -32,12 +32,12 @@ import com.univapay.sdk.utils.mockcontent.ChargesFakeRR;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Duration;
+import java.time.ZoneId;
 import java.util.Date;
 import org.hamcrest.Matchers;
 import org.joda.time.LocalDate;
 import org.junit.Test;
-import org.threeten.bp.Duration;
-import org.threeten.bp.ZoneId;
 
 public class CreateSubscriptionTest extends GenericTest {
 

--- a/src/test/java/com/univapay/sdk/subscription/GetSubscriptionPaymentTest.java
+++ b/src/test/java/com/univapay/sdk/subscription/GetSubscriptionPaymentTest.java
@@ -13,10 +13,10 @@ import com.univapay.sdk.utils.MockRRGenerator;
 import com.univapay.sdk.utils.mockcontent.ChargesFakeRR;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.ZoneId;
 import org.hamcrest.Matchers;
 import org.joda.time.LocalDate;
 import org.junit.Test;
-import org.threeten.bp.ZoneId;
 
 public class GetSubscriptionPaymentTest extends GenericTest {
 

--- a/src/test/java/com/univapay/sdk/subscription/GetSubscriptionTest.java
+++ b/src/test/java/com/univapay/sdk/subscription/GetSubscriptionTest.java
@@ -18,10 +18,10 @@ import com.univapay.sdk.utils.MockRRGenerator;
 import com.univapay.sdk.utils.mockcontent.ChargesFakeRR;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.ZoneId;
 import org.hamcrest.Matchers;
 import org.joda.time.LocalDate;
 import org.junit.Test;
-import org.threeten.bp.ZoneId;
 
 public class GetSubscriptionTest extends GenericTest {
 

--- a/src/test/java/com/univapay/sdk/subscription/ListPaymentsTest.java
+++ b/src/test/java/com/univapay/sdk/subscription/ListPaymentsTest.java
@@ -13,10 +13,10 @@ import com.univapay.sdk.utils.MockRRGenerator;
 import com.univapay.sdk.utils.mockcontent.ChargesFakeRR;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.ZoneId;
 import org.hamcrest.Matchers;
 import org.joda.time.LocalDate;
 import org.junit.Test;
-import org.threeten.bp.ZoneId;
 
 public class ListPaymentsTest extends GenericTest {
 

--- a/src/test/java/com/univapay/sdk/subscription/ListSubscriptionsMerchantTest.java
+++ b/src/test/java/com/univapay/sdk/subscription/ListSubscriptionsMerchantTest.java
@@ -19,10 +19,10 @@ import com.univapay.sdk.utils.mockcontent.ChargesFakeRR;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.ParseException;
+import java.time.ZoneId;
 import org.hamcrest.Matchers;
 import org.joda.time.LocalDate;
 import org.junit.Test;
-import org.threeten.bp.ZoneId;
 
 public class ListSubscriptionsMerchantTest extends GenericTest {
 

--- a/src/test/java/com/univapay/sdk/subscription/ListSubscriptionsTest.java
+++ b/src/test/java/com/univapay/sdk/subscription/ListSubscriptionsTest.java
@@ -19,10 +19,10 @@ import com.univapay.sdk.utils.mockcontent.ChargesFakeRR;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.ParseException;
+import java.time.ZoneId;
 import org.hamcrest.Matchers;
 import org.joda.time.LocalDate;
 import org.junit.Test;
-import org.threeten.bp.ZoneId;
 
 public class ListSubscriptionsTest extends GenericTest {
 

--- a/src/test/java/com/univapay/sdk/subscription/RetrySubscriptionTest.java
+++ b/src/test/java/com/univapay/sdk/subscription/RetrySubscriptionTest.java
@@ -25,11 +25,11 @@ import com.univapay.sdk.utils.mockcontent.ChargesFakeRR;
 import com.univapay.sdk.utils.mockcontent.ErrorsFakeRR;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.ZoneId;
 import org.joda.time.LocalDate;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.threeten.bp.ZoneId;
 
 public class RetrySubscriptionTest extends GenericTest {
 

--- a/src/test/java/com/univapay/sdk/subscription/SimulateSubscriptionPlanTest.java
+++ b/src/test/java/com/univapay/sdk/subscription/SimulateSubscriptionPlanTest.java
@@ -17,11 +17,11 @@ import com.univapay.sdk.utils.GenericTest;
 import com.univapay.sdk.utils.MockRRGenerator;
 import com.univapay.sdk.utils.mockcontent.ChargesFakeRR;
 import java.math.BigInteger;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.UUID;
 import org.joda.time.LocalDate;
 import org.junit.Test;
-import org.threeten.bp.ZoneId;
 
 public class SimulateSubscriptionPlanTest extends GenericTest {
 


### PR DESCRIPTION
Removed org.threeten.bp.*

```
The following dependencies have later milestone versions:
 - com.diffplug.gradle.spotless:com.diffplug.gradle.spotless.gradle.plugin [3.28.0 -> 3.28.1]
 - com.squareup.okhttp3:logging-interceptor [4.4.1 -> 4.5.0]
     https://square.github.io/okhttp/
 - com.squareup.okhttp3:okhttp [4.4.1 -> 4.5.0]
     https://square.github.io/okhttp/
 - com.squareup.retrofit2:converter-gson [2.7.2 -> 2.8.1]
     https://github.com/square/retrofit/
 - com.squareup.retrofit2:retrofit [2.7.2 -> 2.8.1]
     https://github.com/square/retrofit/
 - io.reactivex.rxjava2:rxjava [2.2.18 -> 2.2.19]
     https://github.com/ReactiveX/RxJava
 - org.mockito:mockito-core [3.3.1 -> 3.3.3]
     https://github.com/mockito/mockito
 - org.threeten:threetenbp [1.4.1 -> 1.4.3]
     https://www.threeten.org/threetenbp

Gradle release-candidate updates:
 - Gradle: [6.2.2 -> 6.3]
```