### PR TITLE
Release/v0.1.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "develop"

--- a/README.en.md
+++ b/README.en.md
@@ -12,7 +12,7 @@ To use the UnivaPay Java SDK, add the following dependency to your pom file:
 <dependency>
     <groupId>com.univapay</groupId>
     <artifactId>univapay-java-sdk</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
 </dependency>
 ```
 
@@ -202,4 +202,4 @@ The `asIterable` method provides ways to customize the `timeout` and `backoff` a
 
 ## More
 
-For more details on the UnivaPay API, check the [Javadocs](https://www.javadoc.io/doc/com.univapay/univapay-java-sdk/0.1.0) or the [API Docs](https://docs.univapay.com).
+For more details on the UnivaPay API, check the [Javadocs](https://www.javadoc.io/doc/com.univapay/univapay-java-sdk/0.1.1) or the [API Docs](https://docs.univapay.com).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ UnivaPay Java SDKを利用するには、pomファイルに次の依存関係を
 <dependency>
     <groupId>com.univapay</groupId>
     <artifactId>univapay-java-sdk</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
 </dependency>
 ```
 ## 使用方法
@@ -200,4 +200,4 @@ for(List<Charge> charges: chargesIterable){
 
 ## その他
 
-UnivaPay APIの詳細については、[Javadoc](https://www.javadoc.io/doc/com.univapay/univapay-java-sdk/0.1.0)または[APIリファレンス](https://docs.univapay.com)を参照してください。
+UnivaPay APIの詳細については、[Javadoc](https://www.javadoc.io/doc/com.univapay/univapay-java-sdk/0.1.1)または[APIリファレンス](https://docs.univapay.com)を参照してください。

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     testImplementation 'com.github.tomakehurst:wiremock:2.26.3'
     testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
     testImplementation 'org.slf4j:slf4j-simple:2.0.0-alpha1'
-    testImplementation 'com.google.guava:guava:28.2-jre'
+    testImplementation 'com.google.guava:guava:29.0-jre'
     testImplementation 'it.ozimov:java7-hamcrest-matchers:1.3.0'
     testImplementation 'org.mockito:mockito-core:3.3.3'
     testImplementation 'com.google.zxing:core:3.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 }
 
 group = 'com.univapay'
-version = '0.1.0'
+version = '0.1.1'
 sourceCompatibility = '1.8'
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compile 'com.squareup.retrofit2:retrofit:2.8.1'
     compile 'com.squareup.retrofit2:converter-gson:2.8.1'
     compile 'org.joda:joda-money:1.0.1'
-    compile 'org.json:json:20190722'
+    compile 'org.json:json:20200518'
     compile 'com.google.code.gson:gson:2.8.6'
     compile 'com.google.code.findbugs:jsr305:3.0.2'
     testImplementation 'junit:junit:4.13'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     compile 'io.reactivex.rxjava2:rxjava:2.2.19'
     compile 'com.squareup.okhttp3:okhttp:4.7.2'
     compile 'com.squareup.okhttp3:logging-interceptor:4.5.0'
-    compile 'com.squareup.retrofit2:retrofit:2.8.1'
+    compile 'com.squareup.retrofit2:retrofit:2.9.0'
     compile 'com.squareup.retrofit2:converter-gson:2.8.1'
     compile 'org.joda:joda-money:1.0.1'
     compile 'org.json:json:20200518'

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    compile 'io.reactivex.rxjava2:rxjava:2.2.19'
+    compile 'io.reactivex.rxjava3:rxjava:3.0.4'
     compile 'com.squareup.okhttp3:okhttp:4.7.2'
     compile 'com.squareup.okhttp3:logging-interceptor:4.7.2'
     compile 'com.squareup.retrofit2:retrofit:2.9.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     compile 'com.squareup.retrofit2:converter-gson:2.8.1'
     compile 'org.joda:joda-money:1.0.1'
     compile 'org.json:json:20190722'
-    compile 'com.google.code.gson:gson:2.2.19'
+    compile 'com.google.code.gson:gson:2.8.6'
     compile 'com.google.code.findbugs:jsr305:3.0.2'
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.junit.contrib:junit-theories:5.0-alpha-3'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id "com.github.ben-manes.versions" version "0.28.0"
-    id "com.diffplug.gradle.spotless" version "3.28.1"
+    id "com.diffplug.gradle.spotless" version "4.3.0"
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     compile 'com.squareup.okhttp3:okhttp:4.7.2'
     compile 'com.squareup.okhttp3:logging-interceptor:4.5.0'
     compile 'com.squareup.retrofit2:retrofit:2.9.0'
-    compile 'com.squareup.retrofit2:converter-gson:2.8.1'
+    compile 'com.squareup.retrofit2:converter-gson:2.9.0'
     compile 'org.joda:joda-money:1.0.1'
     compile 'org.json:json:20200518'
     compile 'com.google.code.gson:gson:2.8.6'

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ repositories {
 
 dependencies {
     compile 'io.reactivex.rxjava2:rxjava:2.2.18'
-    compile 'com.squareup.okhttp3:okhttp:4.5.0'
+    compile 'com.squareup.okhttp3:okhttp:4.7.2'
     compile 'com.squareup.okhttp3:logging-interceptor:4.5.0'
     compile 'com.squareup.retrofit2:retrofit:2.8.1'
     compile 'com.squareup.retrofit2:converter-gson:2.8.1'

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
 dependencies {
     compile 'io.reactivex.rxjava2:rxjava:2.2.19'
     compile 'com.squareup.okhttp3:okhttp:4.7.2'
-    compile 'com.squareup.okhttp3:logging-interceptor:4.5.0'
+    compile 'com.squareup.okhttp3:logging-interceptor:4.7.2'
     compile 'com.squareup.retrofit2:retrofit:2.9.0'
     compile 'com.squareup.retrofit2:converter-gson:2.9.0'
     compile 'org.joda:joda-money:1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    compile 'io.reactivex.rxjava2:rxjava:2.2.18'
+    compile 'io.reactivex.rxjava2:rxjava:2.2.19'
     compile 'com.squareup.okhttp3:okhttp:4.7.2'
     compile 'com.squareup.okhttp3:logging-interceptor:4.5.0'
     compile 'com.squareup.retrofit2:retrofit:2.8.1'

--- a/src/main/java/com/univapay/sdk/builders/batch_charge/AbstractBatchCreateCharge.java
+++ b/src/main/java/com/univapay/sdk/builders/batch_charge/AbstractBatchCreateCharge.java
@@ -11,10 +11,10 @@ import com.univapay.sdk.utils.Sleeper;
 import com.univapay.sdk.utils.functions.EndoFunction;
 import com.univapay.sdk.utils.functions.UnivapayFunctions;
 import com.univapay.sdk.utils.streams.StreamOptions;
-import io.reactivex.Flowable;
-import io.reactivex.functions.Consumer;
-import io.reactivex.functions.Function;
-import io.reactivex.schedulers.Schedulers;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.functions.Consumer;
+import io.reactivex.rxjava3.functions.Function;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -109,7 +109,7 @@ public abstract class AbstractBatchCreateCharge<
             streamOptions.getWindowOptions().getLength(),
             streamOptions.getWindowOptions().getTimeUnit(),
             streamOptions.getWindowOptions().getWindowSize())
-        .flatMap(UnivapayFunctions.<Flowable<B>>identity())
+        .flatMap(UnivapayFunctions.identity())
         //              Process the following steps in parallel
         .parallel(streamOptions.getParallelism())
         //              Set an idempotency key for each builder where it hasn't been set

--- a/src/main/java/com/univapay/sdk/utils/functions/EndoFunction.java
+++ b/src/main/java/com/univapay/sdk/utils/functions/EndoFunction.java
@@ -1,5 +1,5 @@
 package com.univapay.sdk.utils.functions;
 
-import io.reactivex.functions.Function;
+import io.reactivex.rxjava3.functions.Function;
 
 public interface EndoFunction<T> extends Function<T, T> {}

--- a/src/main/java/com/univapay/sdk/utils/streams/StreamOptions.java
+++ b/src/main/java/com/univapay/sdk/utils/streams/StreamOptions.java
@@ -1,6 +1,6 @@
 package com.univapay.sdk.utils.streams;
 
-import io.reactivex.annotations.NonNull;
+import io.reactivex.rxjava3.annotations.NonNull;
 import java.util.concurrent.TimeUnit;
 
 public class StreamOptions {

--- a/src/main/java/com/univapay/sdk/utils/streams/WindowOptions.java
+++ b/src/main/java/com/univapay/sdk/utils/streams/WindowOptions.java
@@ -1,6 +1,6 @@
 package com.univapay.sdk.utils.streams;
 
-import io.reactivex.annotations.NonNull;
+import io.reactivex.rxjava3.annotations.NonNull;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 


### PR DESCRIPTION
- Bump com.diffplug.gradle.spotless from 3.28.1 to 4.3.0 (#17)
- Bump gson from 2.2.19 to 2.8.6 (#18)
- Bump okhttp from 4.5.0 to 4.7.2 (#19)
- Bump guava from 28.2-jre to 29.0-jre (#20)
- Bump json from 20190722 to 20200518 (#21)
- Bump rxjava from 2.2.18 to 2.2.19 (#22)
- Bump retrofit from 2.8.1 to 2.9.0 (#24)
- Bump converter-gson from 2.8.1 to 2.9.0 (#23)
- Bump logging-interceptor from 4.5.0 to 4.7.2 (#25)
- Migrate rxjava2 to rxjava3 (#26)
