### PR TITLE
Added the PaymentType Online

### DIFF
--- a/src/main/java/com/univapay/sdk/SDKMethods.java
+++ b/src/main/java/com/univapay/sdk/SDKMethods.java
@@ -9,6 +9,7 @@ import com.univapay.sdk.builders.batch_charge.AbstractBatchCreateCharge;
 import com.univapay.sdk.builders.cancel.AbstractCancelsBuilders;
 import com.univapay.sdk.builders.charge.AbstractChargesBuilders;
 import com.univapay.sdk.builders.exchangerate.AbstractExchangeRateBuilders;
+import com.univapay.sdk.builders.issuerToken.AbstractIssuerTokensBuilders;
 import com.univapay.sdk.builders.ledgers.AbstractLedgersBuilders;
 import com.univapay.sdk.builders.merchant.AbstractMerchantsBuilders;
 import com.univapay.sdk.builders.refund.AbstractRefundBuilders;
@@ -19,7 +20,6 @@ import com.univapay.sdk.builders.transactiontoken.AbstractTransactionTokensBuild
 import com.univapay.sdk.builders.transfer.AbstractTransferBuilders;
 import com.univapay.sdk.builders.utility.AbstractUtilityBuilders;
 import com.univapay.sdk.builders.webhook.AbstractWebhookBuilders;
-import com.univapay.sdk.models.common.*;
 import com.univapay.sdk.models.common.AppJWTId;
 import com.univapay.sdk.models.common.AppTokenId;
 import com.univapay.sdk.models.common.BankAccountId;
@@ -27,6 +27,7 @@ import com.univapay.sdk.models.common.CancelId;
 import com.univapay.sdk.models.common.ChargeId;
 import com.univapay.sdk.models.common.Domain;
 import com.univapay.sdk.models.common.MoneyLike;
+import com.univapay.sdk.models.common.OnlinePayment;
 import com.univapay.sdk.models.common.PaidyPaymentData;
 import com.univapay.sdk.models.common.QrMerchantData;
 import com.univapay.sdk.models.common.QrScanData;
@@ -48,7 +49,6 @@ import com.univapay.sdk.models.response.refund.Refund;
 import com.univapay.sdk.models.response.subscription.FullSubscription;
 import com.univapay.sdk.models.response.transactiontoken.TokenAliasKey;
 import com.univapay.sdk.settings.AbstractSDKSettings;
-import com.univapay.sdk.types.*;
 import com.univapay.sdk.types.BusinessType;
 import com.univapay.sdk.types.PaymentTypeName;
 import com.univapay.sdk.types.RefundReason;
@@ -1062,6 +1062,16 @@ public interface SDKMethods<T extends AbstractSDK> {
       createTransactionToken(QrMerchantData paymentData, TransactionTokenType type);
 
   /**
+   * Create a new transaction token.
+   *
+   * @param paymentData instance of OnlinePayment
+   * @param type the type of the transaction token to be created
+   * @return a request builder.
+   */
+  AbstractTransactionTokensBuilders.AbstractCreateTransactionTokenRequestBuilder
+      createTransactionToken(OnlinePayment paymentData, TransactionTokenType type);
+
+  /**
    * Delete a transaction token.
    *
    * @param storeId the ID of the store associated with the transaction token to be deleted
@@ -1136,6 +1146,16 @@ public interface SDKMethods<T extends AbstractSDK> {
    */
   AbstractTransactionTokensBuilders.AbstractGetTemporaryTokenAliasAsImageRequestBuilder
       getTokenAliasImage(StoreId storeId, TokenAliasKey aliasKey);
+
+  /**
+   * Get the Issuer Token of a charge
+   *
+   * @param storeId the ID of the store
+   * @param chargeId the Id of the charge
+   * @return a request builder
+   */
+  AbstractIssuerTokensBuilders.AbstractGetIssuerTokenRequestBuilder getIssuerToken(
+      StoreId storeId, ChargeId chargeId);
 
   /**
    * Delete a temporary transaction token alias

--- a/src/main/java/com/univapay/sdk/UnivapaySDK.java
+++ b/src/main/java/com/univapay/sdk/UnivapaySDK.java
@@ -8,6 +8,7 @@ import com.univapay.sdk.builders.batch_charge.BatchCreateCharge;
 import com.univapay.sdk.builders.cancel.CancelsBuilders;
 import com.univapay.sdk.builders.charge.ChargesBuilders;
 import com.univapay.sdk.builders.exchangerate.ExchangeRateBuilders;
+import com.univapay.sdk.builders.issuerToken.IssuerTokensBuilders;
 import com.univapay.sdk.builders.ledgers.LedgersBuilders;
 import com.univapay.sdk.builders.merchant.MerchantsBuilders;
 import com.univapay.sdk.builders.refund.RefundBuilders;
@@ -17,7 +18,6 @@ import com.univapay.sdk.builders.transactiontoken.TransactionTokensBuilders;
 import com.univapay.sdk.builders.transfer.TransferBuilders;
 import com.univapay.sdk.builders.utility.UtilityBuilders;
 import com.univapay.sdk.builders.webhook.WebhookBuilders;
-import com.univapay.sdk.models.common.*;
 import com.univapay.sdk.models.common.AppJWTId;
 import com.univapay.sdk.models.common.AppTokenId;
 import com.univapay.sdk.models.common.BankAccountId;
@@ -26,6 +26,7 @@ import com.univapay.sdk.models.common.ChargeId;
 import com.univapay.sdk.models.common.Domain;
 import com.univapay.sdk.models.common.EmailAddress;
 import com.univapay.sdk.models.common.MoneyLike;
+import com.univapay.sdk.models.common.OnlinePayment;
 import com.univapay.sdk.models.common.PaidyPaymentData;
 import com.univapay.sdk.models.common.QrMerchantData;
 import com.univapay.sdk.models.common.QrScanData;
@@ -36,7 +37,6 @@ import com.univapay.sdk.models.common.SubscriptionId;
 import com.univapay.sdk.models.common.TransactionTokenId;
 import com.univapay.sdk.models.common.TransferId;
 import com.univapay.sdk.models.common.WebhookId;
-import com.univapay.sdk.models.common.auth.*;
 import com.univapay.sdk.models.common.auth.AppJWTStrategy;
 import com.univapay.sdk.models.common.auth.AppTokenStrategy;
 import com.univapay.sdk.models.common.auth.AuthStrategy;
@@ -56,7 +56,6 @@ import com.univapay.sdk.models.response.subscription.FullSubscription;
 import com.univapay.sdk.models.response.transactiontoken.TokenAliasKey;
 import com.univapay.sdk.settings.AbstractSDKSettings;
 import com.univapay.sdk.settings.UnivapaySettings;
-import com.univapay.sdk.types.*;
 import com.univapay.sdk.types.BusinessType;
 import com.univapay.sdk.types.PaymentTypeName;
 import com.univapay.sdk.types.RefundReason;
@@ -875,6 +874,13 @@ public class UnivapaySDK extends AbstractSDK implements SDKMethods<UnivapaySDK>,
 
   @Override
   public TransactionTokensBuilders.CreateTransactionTokenRequestBuilder createTransactionToken(
+      OnlinePayment paymentData, TransactionTokenType type) {
+    return new TransactionTokensBuilders.CreateTransactionTokenRequestBuilder(
+        retrofit, null, paymentData, type);
+  }
+
+  @Override
+  public TransactionTokensBuilders.CreateTransactionTokenRequestBuilder createTransactionToken(
       QrMerchantData paymentData, TransactionTokenType type) {
     return new TransactionTokensBuilders.CreateTransactionTokenRequestBuilder(
         retrofit, null, paymentData, type);
@@ -932,6 +938,11 @@ public class UnivapaySDK extends AbstractSDK implements SDKMethods<UnivapaySDK>,
       StoreId storeId, TokenAliasKey aliasKey) {
     return new TransactionTokensBuilders.GetTemporaryTokenAliasAsImageRequestBuilder(
         retrofit, storeId, aliasKey);
+  }
+
+  @Override
+  public IssuerTokensBuilders.GetIssuerToken getIssuerToken(StoreId storeId, ChargeId chargeId) {
+    return new IssuerTokensBuilders.GetIssuerToken(retrofit, storeId, chargeId);
   }
 
   @Override

--- a/src/main/java/com/univapay/sdk/builders/issuerToken/AbstractIssuerTokensBuilders.java
+++ b/src/main/java/com/univapay/sdk/builders/issuerToken/AbstractIssuerTokensBuilders.java
@@ -1,0 +1,25 @@
+package com.univapay.sdk.builders.issuerToken;
+
+import com.univapay.sdk.builders.RetrofitRequestBuilder;
+import com.univapay.sdk.models.common.ChargeId;
+import com.univapay.sdk.models.common.StoreId;
+import com.univapay.sdk.models.response.IssuerToken;
+import retrofit2.Retrofit;
+
+public class AbstractIssuerTokensBuilders {
+
+  public abstract static class AbstractGetIssuerTokenRequestBuilder<
+          B extends AbstractGetIssuerTokenRequestBuilder<B, R, M>, R, M extends IssuerToken>
+      extends RetrofitRequestBuilder<M, R> {
+
+    protected StoreId storeId;
+    protected ChargeId chargeId;
+
+    public AbstractGetIssuerTokenRequestBuilder(
+        Retrofit retrofit, StoreId storeId, ChargeId chargeId) {
+      super(retrofit);
+      this.storeId = storeId;
+      this.chargeId = chargeId;
+    }
+  }
+}

--- a/src/main/java/com/univapay/sdk/builders/issuerToken/IssuerTokensBuilders.java
+++ b/src/main/java/com/univapay/sdk/builders/issuerToken/IssuerTokensBuilders.java
@@ -1,0 +1,26 @@
+package com.univapay.sdk.builders.issuerToken;
+
+import com.univapay.sdk.models.common.ChargeId;
+import com.univapay.sdk.models.common.StoreId;
+import com.univapay.sdk.models.response.IssuerToken;
+import com.univapay.sdk.resources.IssuerTokensResource;
+import retrofit2.Call;
+import retrofit2.Retrofit;
+
+public class IssuerTokensBuilders {
+
+  /** Get the IssuerToken of a Charge using the /stores/{storeId}/charges/{id}/issuerToken route */
+  public static class GetIssuerToken
+      extends AbstractIssuerTokensBuilders.AbstractGetIssuerTokenRequestBuilder<
+          GetIssuerToken, IssuerTokensResource, IssuerToken> {
+
+    public GetIssuerToken(Retrofit retrofit, StoreId storeId, ChargeId chargeId) {
+      super(retrofit, storeId, chargeId);
+    }
+
+    @Override
+    protected Call<IssuerToken> getRequest(IssuerTokensResource resource) {
+      return resource.getChargeIssuerToken(storeId, chargeId);
+    }
+  }
+}

--- a/src/main/java/com/univapay/sdk/models/common/CallMethod.java
+++ b/src/main/java/com/univapay/sdk/models/common/CallMethod.java
@@ -1,0 +1,17 @@
+package com.univapay.sdk.models.common;
+
+import com.google.gson.annotations.SerializedName;
+
+/** Representation of the method that is used to consume the issuerToken */
+public enum CallMethod {
+
+  /** The issuer token is a HTTP endpoint, invoked with GET */
+  @SerializedName("http_get")
+  HTTP_GET,
+  /** The issuer token is a HTTP endpoint, invoked with POST */
+  @SerializedName("http_post")
+  HTTP_POST,
+  /** The issuer token should be forwarded to the service's provided SDK */
+  @SerializedName("sdk")
+  SDK
+}

--- a/src/main/java/com/univapay/sdk/models/common/OnlinePayment.java
+++ b/src/main/java/com/univapay/sdk/models/common/OnlinePayment.java
@@ -1,0 +1,26 @@
+package com.univapay.sdk.models.common;
+
+import com.google.gson.annotations.SerializedName;
+import com.univapay.sdk.models.request.transactiontoken.PaymentData;
+import com.univapay.sdk.types.Gateway;
+import com.univapay.sdk.types.PaymentTypeName;
+
+public class OnlinePayment implements PaymentData {
+
+  /** This defines which service will be used when creating the TransactionToken & Charge */
+  @SerializedName("gateway")
+  private final Gateway gateway;
+
+  @Override
+  public PaymentTypeName getPaymentType() {
+    return PaymentTypeName.ONLINE;
+  }
+
+  public OnlinePayment(Gateway gateway) {
+    this.gateway = gateway;
+  }
+
+  public Gateway getGateway() {
+    return gateway;
+  }
+}

--- a/src/main/java/com/univapay/sdk/models/response/IssuerToken.java
+++ b/src/main/java/com/univapay/sdk/models/response/IssuerToken.java
@@ -1,0 +1,26 @@
+package com.univapay.sdk.models.response;
+
+import com.google.gson.annotations.SerializedName;
+import com.univapay.sdk.models.common.CallMethod;
+
+public class IssuerToken extends UnivapayResponse {
+
+  @SerializedName("call_method")
+  private final CallMethod callMethod;
+
+  @SerializedName("issuer_token")
+  private final String issuerToken;
+
+  public IssuerToken(CallMethod callMethod, String issuerToken) {
+    this.callMethod = callMethod;
+    this.issuerToken = issuerToken;
+  }
+
+  public String getIssuerToken() {
+    return issuerToken;
+  }
+
+  public CallMethod getCallMethod() {
+    return callMethod;
+  }
+}

--- a/src/main/java/com/univapay/sdk/models/response/transactiontoken/OnlinePaymentData.java
+++ b/src/main/java/com/univapay/sdk/models/response/transactiontoken/OnlinePaymentData.java
@@ -1,0 +1,30 @@
+package com.univapay.sdk.models.response.transactiontoken;
+
+import com.univapay.sdk.models.common.CallMethod;
+import com.univapay.sdk.types.Gateway;
+
+/** This represents the online payment data for the TransactionToken response */
+public class OnlinePaymentData {
+
+  private final Gateway gateway;
+  private final String issuerToken;
+  private final CallMethod callMethod;
+
+  public OnlinePaymentData(Gateway gateway, String issuerToken, CallMethod callMethod) {
+    this.gateway = gateway;
+    this.issuerToken = issuerToken;
+    this.callMethod = callMethod;
+  }
+
+  public Gateway getGateway() {
+    return gateway;
+  }
+
+  public String getIssuerToken() {
+    return issuerToken;
+  }
+
+  public CallMethod getCallMethod() {
+    return callMethod;
+  }
+}

--- a/src/main/java/com/univapay/sdk/models/response/transactiontoken/PaymentData.java
+++ b/src/main/java/com/univapay/sdk/models/response/transactiontoken/PaymentData.java
@@ -1,6 +1,7 @@
 package com.univapay.sdk.models.response.transactiontoken;
 
 import com.google.gson.annotations.SerializedName;
+import com.univapay.sdk.models.common.CallMethod;
 import com.univapay.sdk.models.common.PaidyPaymentData;
 import com.univapay.sdk.models.common.PaidyShippingAddress;
 import com.univapay.sdk.models.common.PaidyToken;
@@ -46,6 +47,12 @@ public class PaymentData {
 
   @SerializedName("brand")
   private QRBrand brand;
+
+  @SerializedName("call_method")
+  private CallMethod callMethod;
+
+  @SerializedName("issuer_token")
+  private String issuerToken;
 
   public TransactionTokenCardData getCard() {
     return card;
@@ -97,5 +104,9 @@ public class PaymentData {
 
   public QrMerchantPaymentData asQrMerchantPaymentData() {
     return new QrMerchantPaymentData(qrImageUrl, industry, gateway);
+  }
+
+  public OnlinePaymentData asOnlinePaymentData() {
+    return new OnlinePaymentData(gateway, issuerToken, callMethod);
   }
 }

--- a/src/main/java/com/univapay/sdk/resources/IssuerTokensResource.java
+++ b/src/main/java/com/univapay/sdk/resources/IssuerTokensResource.java
@@ -1,0 +1,13 @@
+package com.univapay.sdk.resources;
+
+import com.univapay.sdk.models.common.ChargeId;
+import com.univapay.sdk.models.common.StoreId;
+import com.univapay.sdk.models.response.IssuerToken;
+import retrofit2.Call;
+import retrofit2.http.*;
+
+public interface IssuerTokensResource {
+
+  @GET("/stores/{storeId}/charges/{id}/issuerToken")
+  Call<IssuerToken> getChargeIssuerToken(@Path("storeId") StoreId storeId, @Path("id") ChargeId id);
+}

--- a/src/main/java/com/univapay/sdk/types/PaymentTypeName.java
+++ b/src/main/java/com/univapay/sdk/types/PaymentTypeName.java
@@ -14,5 +14,7 @@ public enum PaymentTypeName {
   @SerializedName("konbini")
   KONBINI,
   @SerializedName("paidy")
-  PAIDY
+  PAIDY,
+  @SerializedName("online")
+  ONLINE
 }

--- a/src/test/java/com/univapay/sdk/issuerToken/GetIssuerTokenTest.java
+++ b/src/test/java/com/univapay/sdk/issuerToken/GetIssuerTokenTest.java
@@ -1,0 +1,46 @@
+package com.univapay.sdk.issuerToken;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import com.univapay.sdk.UnivapaySDK;
+import com.univapay.sdk.models.common.CallMethod;
+import com.univapay.sdk.models.common.ChargeId;
+import com.univapay.sdk.models.common.StoreId;
+import com.univapay.sdk.models.errors.UnivapayException;
+import com.univapay.sdk.models.response.IssuerToken;
+import com.univapay.sdk.types.AuthType;
+import com.univapay.sdk.utils.GenericTest;
+import com.univapay.sdk.utils.MockRRGenerator;
+import com.univapay.sdk.utils.mockcontent.IssuerTokensFakeRR;
+import java.io.IOException;
+import org.junit.Test;
+
+public class GetIssuerTokenTest extends GenericTest {
+
+  @Test
+  public void shouldReturnTheIssuerTokenOfCharge() throws IOException, UnivapayException {
+
+    // Do a query for the issue token
+
+    MockRRGenerator mockRRGenerator = new MockRRGenerator();
+    mockRRGenerator.GenerateMockRequestResponseJWT(
+        "GET",
+        "/stores/653ef5a3-73f2-408a-bac5-7058835f7700/charges/425e88b7-b588-4247-80ee-0ea0caff1190/issuerToken",
+        jwt,
+        200,
+        IssuerTokensFakeRR.getIssuerTokenFakeResponse);
+
+    UnivapaySDK sdk = createTestInstance(AuthType.JWT);
+
+    IssuerToken issuerToken =
+        sdk.getIssuerToken(
+                new StoreId("653ef5a3-73f2-408a-bac5-7058835f7700"),
+                new ChargeId("425e88b7-b588-4247-80ee-0ea0caff1190"))
+            .dispatch();
+
+    assertThat(issuerToken, is(notNullValue()));
+    assertThat(issuerToken.getCallMethod(), is(CallMethod.HTTP_GET));
+    assertThat(issuerToken.getIssuerToken(), is("TOKEN"));
+  }
+}

--- a/src/test/java/com/univapay/sdk/models/common/paymentData/online/OnlinePaymentTest.java
+++ b/src/test/java/com/univapay/sdk/models/common/paymentData/online/OnlinePaymentTest.java
@@ -1,0 +1,29 @@
+package com.univapay.sdk.models.common.paymentData.online;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
+
+import com.google.gson.Gson;
+import com.univapay.sdk.models.common.OnlinePayment;
+import com.univapay.sdk.types.Gateway;
+import com.univapay.sdk.utils.RequestUtils;
+import com.univapay.sdk.utils.mockcontent.JsonLoader;
+import org.junit.Test;
+
+public class OnlinePaymentTest {
+
+  // Responsible to check GSON can  read / write the OnlinePayment class
+  @Test
+  public void shouldReadOnlinePayment() {
+
+    OnlinePayment expected = new OnlinePayment(Gateway.ALIPAY_CONNECT);
+
+    String json = JsonLoader.loadJson("serialization/online.json");
+
+    final Gson gson = RequestUtils.getGson();
+
+    OnlinePayment onlinePayment = gson.fromJson(json, OnlinePayment.class);
+
+    assertThat(onlinePayment, samePropertyValuesAs(expected));
+  }
+}

--- a/src/test/java/com/univapay/sdk/transactiontoken/CreateTransactionTokenTest.java
+++ b/src/test/java/com/univapay/sdk/transactiontoken/CreateTransactionTokenTest.java
@@ -1,51 +1,31 @@
 package com.univapay.sdk.transactiontoken;
 
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.core.Is.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import com.univapay.sdk.UnivapaySDK;
 import com.univapay.sdk.builders.transactiontoken.TransactionTokensBuilders;
 import com.univapay.sdk.models.common.*;
-import com.univapay.sdk.models.common.ApplePay;
-import com.univapay.sdk.models.common.CreditCard;
-import com.univapay.sdk.models.common.KonbiniPayment;
-import com.univapay.sdk.models.common.PaidyPaymentData;
-import com.univapay.sdk.models.common.PaidyShippingAddress;
-import com.univapay.sdk.models.common.PaidyToken;
-import com.univapay.sdk.models.common.QrMerchantData;
-import com.univapay.sdk.models.common.QrScanData;
-import com.univapay.sdk.models.common.UnivapayCustomerId;
+import com.univapay.sdk.models.common.OnlinePayment;
 import com.univapay.sdk.models.common.auth.AppJWTStrategy;
 import com.univapay.sdk.models.common.auth.AppTokenStrategy;
 import com.univapay.sdk.models.errors.UnivapayException;
+import com.univapay.sdk.models.response.transactiontoken.OnlinePaymentData;
 import com.univapay.sdk.models.response.transactiontoken.PhoneNumber;
 import com.univapay.sdk.models.response.transactiontoken.TransactionToken;
 import com.univapay.sdk.models.response.transactiontoken.TransactionTokenWithData;
 import com.univapay.sdk.types.*;
-import com.univapay.sdk.types.AuthType;
-import com.univapay.sdk.types.CardBrand;
-import com.univapay.sdk.types.Country;
-import com.univapay.sdk.types.Gateway;
-import com.univapay.sdk.types.Konbini;
-import com.univapay.sdk.types.MetadataMap;
-import com.univapay.sdk.types.PaymentTypeName;
-import com.univapay.sdk.types.ProcessingMode;
-import com.univapay.sdk.types.RecurringTokenInterval;
-import com.univapay.sdk.types.TransactionTokenType;
 import com.univapay.sdk.utils.*;
-import com.univapay.sdk.utils.GenericTest;
-import com.univapay.sdk.utils.MockRRGenerator;
-import com.univapay.sdk.utils.MockRRGeneratorWithAppTokenSecret;
-import com.univapay.sdk.utils.UnivapayCallback;
-import com.univapay.sdk.utils.UnivapayDebugSettings;
 import com.univapay.sdk.utils.metadataadapter.MetadataFloatAdapter;
 import com.univapay.sdk.utils.mockcontent.StoreFakeRR;
 import java.io.IOException;
-import java.text.ParseException;
 import java.time.OffsetDateTime;
 import java.time.Period;
-import java.util.*;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
 import org.hamcrest.core.Is;
 import org.junit.Test;
 
@@ -59,8 +39,7 @@ public class CreateTransactionTokenTest extends GenericTest {
   }
 
   @Test
-  public void shouldPostAndReturnTransactionTokenInfoWithCreditCard()
-      throws InterruptedException, ParseException {
+  public void shouldPostAndReturnTransactionTokenInfoWithCreditCard() throws InterruptedException {
     MockRRGeneratorWithAppTokenSecret mockRRGenerator = new MockRRGeneratorWithAppTokenSecret();
     mockRRGenerator.GenerateMockRequestResponse(
         "POST",
@@ -74,7 +53,6 @@ public class CreateTransactionTokenTest extends GenericTest {
     UnivapaySDK univapay = createTestInstance(AuthType.APP_TOKEN);
 
     final OffsetDateTime parsedDate = parseDate("2017-06-22T16:00:55.436116+09:00");
-    ;
 
     final MetadataMap metadata = new MetadataMap();
     final String floatKey = "float";
@@ -182,7 +160,7 @@ public class CreateTransactionTokenTest extends GenericTest {
 
   @Test
   public void shouldPostAndReturnTransactionTokenInfoWithCreditCardHasNoCVV()
-      throws InterruptedException, ParseException {
+      throws InterruptedException {
     MockRRGeneratorWithAppTokenSecret mockRRGenerator = new MockRRGeneratorWithAppTokenSecret();
     mockRRGenerator.GenerateMockRequestResponse(
         "POST",
@@ -196,7 +174,6 @@ public class CreateTransactionTokenTest extends GenericTest {
     UnivapaySDK univapay = createTestInstance(AuthType.APP_TOKEN);
 
     final OffsetDateTime parsedDate = parseDate("2017-06-22T16:00:55.436116+09:00");
-    ;
 
     univapay
         .createTransactionToken(
@@ -240,8 +217,7 @@ public class CreateTransactionTokenTest extends GenericTest {
   }
 
   @Test
-  public void shouldPostAndReturnTransactionTokenInfoWithQrScan()
-      throws InterruptedException, ParseException {
+  public void shouldPostAndReturnTransactionTokenInfoWithQrScan() throws InterruptedException {
     MockRRGeneratorWithAppTokenSecret mockRRGenerator = new MockRRGeneratorWithAppTokenSecret();
     mockRRGenerator.GenerateMockRequestResponse(
         "POST",
@@ -255,7 +231,6 @@ public class CreateTransactionTokenTest extends GenericTest {
     UnivapaySDK univapay = createTestInstance(AuthType.APP_TOKEN);
 
     final OffsetDateTime parsedDate = parseDate("2017-06-22T16:00:55.436116+09:00");
-    ;
 
     univapay
         .createTransactionToken(
@@ -285,7 +260,7 @@ public class CreateTransactionTokenTest extends GenericTest {
 
   @Test
   public void shouldPostAndReturnRecurringTransactionTokenWithUsageLimit()
-      throws InterruptedException, ParseException {
+      throws InterruptedException {
     MockRRGeneratorWithAppTokenSecret mockRRGenerator = new MockRRGeneratorWithAppTokenSecret();
     mockRRGenerator.GenerateMockRequestResponse(
         "POST",
@@ -299,13 +274,12 @@ public class CreateTransactionTokenTest extends GenericTest {
     UnivapaySDK univapay = createTestInstance(AuthType.APP_TOKEN);
 
     final OffsetDateTime parsedDate = parseDate("2017-06-22T16:00:55.436116+09:00");
-    ;
 
     univapay
         .createTransactionToken(
             "some@email.com",
             new CreditCard("full name", "4556137309615276", 12, 2018, 599)
-                .addAddress("JP", null, "Tokyo", "somewhere", null, "111-1111"),
+                .addAddress(Country.JAPAN, null, "Tokyo", "somewhere", null, "111-1111"),
             TransactionTokenType.RECURRING)
         .withUsageLimit(RecurringTokenInterval.WEEKLY)
         .build()
@@ -345,8 +319,7 @@ public class CreateTransactionTokenTest extends GenericTest {
   }
 
   @Test
-  public void shouldPostAndReturnTransactionTokenWithApplePayData()
-      throws InterruptedException, ParseException {
+  public void shouldPostAndReturnTransactionTokenWithApplePayData() throws InterruptedException {
     MockRRGeneratorWithAppTokenSecret mockRRGenerator = new MockRRGeneratorWithAppTokenSecret();
     mockRRGenerator.GenerateMockRequestResponse(
         "POST",
@@ -360,7 +333,6 @@ public class CreateTransactionTokenTest extends GenericTest {
     UnivapaySDK univapay = createTestInstance(AuthType.APP_TOKEN);
 
     final OffsetDateTime parsedDate = parseDate("2017-06-22T16:00:55.436116+09:00");
-    ;
 
     univapay
         .createTransactionToken(
@@ -449,7 +421,7 @@ public class CreateTransactionTokenTest extends GenericTest {
 
   @Test
   public void shouldPostAndReturnTransactionTokenWithKonbiniPaymentData()
-      throws InterruptedException, ParseException {
+      throws InterruptedException {
     MockRRGeneratorWithAppTokenSecret mockRRGenerator = new MockRRGeneratorWithAppTokenSecret();
     mockRRGenerator.GenerateMockRequestResponse(
         "POST",
@@ -608,7 +580,7 @@ public class CreateTransactionTokenTest extends GenericTest {
             .createTransactionToken(
                 "some@email.com",
                 new CreditCard("full name", "4556137309615276", 12, 2018, 599)
-                    .addAddress("JP", null, "Tokyo", "somewhere", null, "111-1111"),
+                    .addAddress(Country.JAPAN, null, "Tokyo", "somewhere", null, "111-1111"),
                 TransactionTokenType.ONE_TIME)
             .withMetadata(metadata, adapter)
             .withUseConfirmation(true)
@@ -642,7 +614,6 @@ public class CreateTransactionTokenTest extends GenericTest {
                 .withRequestsLogging(true));
 
     final OffsetDateTime parsedDate = parseDate("2017-06-22T16:00:55.436116+09:00");
-    ;
 
     final MetadataMap metadata = new MetadataMap();
     final String floatKey = "float";
@@ -709,7 +680,6 @@ public class CreateTransactionTokenTest extends GenericTest {
                 .withRequestsLogging(true));
 
     final OffsetDateTime parsedDate = parseDate("2017-06-22T16:00:55.436116+09:00");
-    ;
 
     final MetadataMap metadata = new MetadataMap();
     final String floatKey = "float";
@@ -766,7 +736,6 @@ public class CreateTransactionTokenTest extends GenericTest {
     UnivapaySDK univapay = createTestInstance(AuthType.APP_TOKEN);
 
     final OffsetDateTime parsedDate = parseDate("2017-06-22T16:00:55.436116+09:00");
-    ;
 
     final String email = "paidy-test@univapay.com";
     final PaidyShippingAddress shippingAddress =
@@ -846,7 +815,7 @@ public class CreateTransactionTokenTest extends GenericTest {
     UnivapaySDK univapay = createTestInstance(AuthType.APP_TOKEN);
 
     final OffsetDateTime parsedDate = parseDate("2017-06-22T16:00:55.436116+09:00");
-    ;
+
     final PaidyShippingAddress shippingAddress =
         new PaidyShippingAddress("106-0032")
             .addState("東京都")
@@ -908,7 +877,6 @@ public class CreateTransactionTokenTest extends GenericTest {
     UnivapaySDK univapay = createTestInstance(AuthType.APP_TOKEN);
 
     final OffsetDateTime parsedDate = parseDate("2017-06-22T16:00:55.436116+09:00");
-    ;
 
     TransactionTokenWithData token =
         univapay
@@ -942,7 +910,6 @@ public class CreateTransactionTokenTest extends GenericTest {
     UnivapaySDK univapay = createTestInstance(AuthType.APP_TOKEN);
 
     final OffsetDateTime parsedDate = parseDate("2017-06-22T16:00:55.436116+09:00");
-    ;
 
     final String email = "test@univapay.com";
     final QrMerchantData paymentData = new QrMerchantData("1234", Gateway.ALIPAY_MERCHANT_QR);
@@ -1000,7 +967,6 @@ public class CreateTransactionTokenTest extends GenericTest {
     UnivapaySDK univapay = createTestInstance(AuthType.APP_TOKEN);
 
     final OffsetDateTime parsedDate = parseDate("2017-06-22T16:00:55.436116+09:00");
-    ;
 
     final QrMerchantData paymentData = new QrMerchantData("1234", Gateway.ALIPAY_MERCHANT_QR);
     TransactionTokenWithData token =
@@ -1021,5 +987,46 @@ public class CreateTransactionTokenTest extends GenericTest {
         token.getData().asQrMerchantPaymentData().getIndustry(), is(paymentData.getIndustry()));
     assertThat(
         token.getData().asQrMerchantPaymentData().getGateway(), is(Gateway.ALIPAY_MERCHANT_QR));
+  }
+
+  @Test
+  public void shouldBeAbleToCreateTransactionTokenWithOnlinePaymentData()
+      throws IOException, UnivapayException {
+
+    final OffsetDateTime expectedDate = parseDate("2017-06-22T16:00:55.436116+09:00");
+
+    MockRRGeneratorWithAppTokenSecret mockRRGenerator = new MockRRGeneratorWithAppTokenSecret();
+    mockRRGenerator.GenerateMockRequestResponse(
+        "POST",
+        "/tokens",
+        appToken,
+        secret,
+        200,
+        StoreFakeRR.createNoEmailTransactionTokenWithOnlinePaymentFakeResponse,
+        StoreFakeRR.createNoEmailTransactionTokenWithOnlinePaymentFakeRequest);
+
+    UnivapaySDK sdk = createTestInstance(AuthType.APP_TOKEN);
+
+    // To create a Online Payment, the only thing required is the intended payment processor
+    OnlinePayment test = new OnlinePayment(Gateway.TEST);
+
+    // Create the Online Payment
+    TransactionTokenWithData token =
+        sdk.createTransactionToken(test, TransactionTokenType.ONE_TIME).dispatch();
+
+    assertThat(token.getId().toString(), is("004b391f-1c98-43f8-87de-28b21aaaca00"));
+    assertThat(token.getStoreId().toString(), is("bf75472e-7f2d-4745-a66d-9b96ae031c7a"));
+    assertThat(token.getEmail(), is(nullValue()));
+    assertThat(token.getMode(), is(ProcessingMode.LIVE));
+    assertThat(token.getCreatedOn(), is(expectedDate));
+    assertThat(token.getLastUsedOn(), is(nullValue()));
+    assertThat(token.getPaymentTypeName(), is(PaymentTypeName.ONLINE));
+
+    OnlinePaymentData onlinePaymentData = token.getData().asOnlinePaymentData();
+    assertThat(onlinePaymentData, is(notNullValue()));
+    assertThat(onlinePaymentData.getGateway(), is(Gateway.TEST));
+    // These will be provided if the charge is successfully processed to the Deferred status
+    assertThat(onlinePaymentData.getCallMethod(), is(nullValue()));
+    assertThat(onlinePaymentData.getCallMethod(), is(nullValue()));
   }
 }

--- a/src/test/java/com/univapay/sdk/transactiontoken/GetTransactionTokenTest.java
+++ b/src/test/java/com/univapay/sdk/transactiontoken/GetTransactionTokenTest.java
@@ -1,24 +1,19 @@
 package com.univapay.sdk.transactiontoken;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.*;
 
 import com.univapay.sdk.UnivapaySDK;
+import com.univapay.sdk.models.common.CallMethod;
 import com.univapay.sdk.models.common.StoreId;
 import com.univapay.sdk.models.common.TransactionTokenId;
 import com.univapay.sdk.models.errors.UnivapayException;
+import com.univapay.sdk.models.response.transactiontoken.OnlinePaymentData;
 import com.univapay.sdk.models.response.transactiontoken.QrScanPaymentData;
 import com.univapay.sdk.models.response.transactiontoken.TransactionTokenWithData;
 import com.univapay.sdk.types.*;
-import com.univapay.sdk.types.AuthType;
-import com.univapay.sdk.types.CardBrand;
-import com.univapay.sdk.types.CardCategory;
-import com.univapay.sdk.types.CardSubBrand;
-import com.univapay.sdk.types.Gateway;
-import com.univapay.sdk.types.PaymentTypeName;
-import com.univapay.sdk.types.ProcessingMode;
-import com.univapay.sdk.types.QRBrand;
 import com.univapay.sdk.utils.GenericTest;
 import com.univapay.sdk.utils.MockRRGenerator;
 import com.univapay.sdk.utils.UnivapayCallback;
@@ -26,7 +21,6 @@ import com.univapay.sdk.utils.mockcontent.JsonLoader;
 import com.univapay.sdk.utils.mockcontent.StoreFakeRR;
 import java.io.IOException;
 import java.time.OffsetDateTime;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 public class GetTransactionTokenTest extends GenericTest {
@@ -66,11 +60,9 @@ public class GetTransactionTokenTest extends GenericTest {
                 assertEquals(response.getData().getCard().getExpYear(), 2018);
                 assertEquals(response.getData().getCard().getLastFour(), 5276);
                 assertEquals(response.getData().getCard().getBrandEnum(), CardBrand.VISA);
-                assertThat(
-                    response.getData().getCard().getCategory(), Matchers.is(CardCategory.CLASSIC));
+                assertThat(response.getData().getCard().getCategory(), is(CardCategory.CLASSIC));
                 assertThat(response.getData().getCard().getIssuer(), is("test issuer"));
-                assertThat(
-                    response.getData().getCard().getSubBrand(), Matchers.is(CardSubBrand.NONE));
+                assertThat(response.getData().getCard().getSubBrand(), is(CardSubBrand.NONE));
                 assertEquals(response.getData().getBilling().getLine1(), "somewhere");
                 assertNull(response.getData().getBilling().getLine2());
                 assertNull(response.getData().getBilling().getState());
@@ -131,8 +123,8 @@ public class GetTransactionTokenTest extends GenericTest {
             .dispatch();
 
     QrScanPaymentData data = response.getData().asQrScanData();
-    assertThat(data.getGateway(), Matchers.is(Gateway.ORIGAMI));
-    assertThat(data.getBrand(), Matchers.is(QRBrand.ORIGAMI));
+    assertThat(data.getGateway(), is(Gateway.ORIGAMI));
+    assertThat(data.getBrand(), is(QRBrand.ORIGAMI));
   }
 
   @Test
@@ -158,5 +150,30 @@ public class GetTransactionTokenTest extends GenericTest {
     QrScanPaymentData data = response.getData().asQrScanData();
     assertThat(data.getGateway(), is(Gateway.ORIGAMI));
     assertThat(data.getBrand(), is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnIssuerTokenAndCallMethodIfAvailable()
+      throws IOException, UnivapayException {
+    MockRRGenerator mockRRGenerator = new MockRRGenerator();
+    mockRRGenerator.GenerateMockRequestResponseJWT(
+        "GET",
+        "/stores/bf75472e-7f2d-4745-a66d-9b96ae031c7a/tokens/004b391f-1c98-43f8-87de-28b21aaaca00",
+        jwt,
+        200,
+        StoreFakeRR.getNoEmailTransactionTokenWithOnlinePaymentFakeResponse);
+
+    UnivapaySDK sdk = createTestInstance(AuthType.JWT);
+    TransactionTokenWithData response =
+        sdk.getTransactionToken(
+                new StoreId("bf75472e-7f2d-4745-a66d-9b96ae031c7a"),
+                new TransactionTokenId("004b391f-1c98-43f8-87de-28b21aaaca00"))
+            .build()
+            .dispatch();
+
+    OnlinePaymentData data = response.getData().asOnlinePaymentData();
+    assertThat(data.getGateway(), is(Gateway.TEST));
+    assertThat(data.getCallMethod(), is(CallMethod.SDK));
+    assertThat(data.getIssuerToken(), is("TOKEN"));
   }
 }

--- a/src/test/java/com/univapay/sdk/utils/mockcontent/IssuerTokensFakeRR.java
+++ b/src/test/java/com/univapay/sdk/utils/mockcontent/IssuerTokensFakeRR.java
@@ -1,0 +1,6 @@
+package com.univapay.sdk.utils.mockcontent;
+
+public class IssuerTokensFakeRR {
+  public static final String getIssuerTokenFakeResponse =
+      JsonLoader.loadJson("responses/issuerToken/get-issuer-token.json");
+}

--- a/src/test/java/com/univapay/sdk/utils/mockcontent/StoreFakeRR.java
+++ b/src/test/java/com/univapay/sdk/utils/mockcontent/StoreFakeRR.java
@@ -860,6 +860,11 @@ public class StoreFakeRR {
           + "    }"
           + "}";
 
+  public static String createNoEmailTransactionTokenWithOnlinePaymentFakeResponse =
+      JsonLoader.loadJson("responses/transactiontoken/post-online-no-email.json");
+  public static String createNoEmailTransactionTokenWithOnlinePaymentFakeRequest =
+      JsonLoader.loadJson("requests/transactiontoken/post-online-no-email.json");
+
   public static String createRecurringTransactionTokenFakeRequest =
       "{\"payment_type\":\"card\",\"email\":\"some@email.com\",\"type\":\"recurring\", \"metadata\" : { }, \"usage_limit\":\"weekly\" ,\"data\":{\"cardholder\":\"full name\",\"card_number\":\"4556137309615276\",\"exp_month\":12,\"exp_year\":2018,\"cvv\":599,\"line1\":\"somewhere\",\"city\":\"Tokyo\",\"country\":\"JP\",\"zip\":\"111-1111\"}}";
 
@@ -1302,4 +1307,7 @@ public class StoreFakeRR {
 
   public static String createCustomerIdFakeResponse =
       "{\n" + "    \"customer_id\": \"004a7593-8071-439a-8000-788a79579ac4\"\n" + "}";
+
+  public static String getNoEmailTransactionTokenWithOnlinePaymentFakeResponse =
+      JsonLoader.loadJson("responses/transactiontoken/get-online-no-email-full.json");
 }

--- a/src/test/resources/requests/transactiontoken/post-online-no-email.json
+++ b/src/test/resources/requests/transactiontoken/post-online-no-email.json
@@ -1,0 +1,8 @@
+{
+  "payment_type": "online",
+  "type": "one_time",
+  "metadata": {},
+  "data": {
+    "gateway": "test"
+  }
+}

--- a/src/test/resources/responses/issuerToken/get-issuer-token.json
+++ b/src/test/resources/responses/issuerToken/get-issuer-token.json
@@ -1,0 +1,4 @@
+{
+  "issuer_token" : "TOKEN",
+  "call_method" : "http_get"
+}

--- a/src/test/resources/responses/transactiontoken/get-online-no-email-full.json
+++ b/src/test/resources/responses/transactiontoken/get-online-no-email-full.json
@@ -1,0 +1,14 @@
+{
+  "id": "004b391f-1c98-43f8-87de-28b21aaaca00",
+  "store_id": "bf75472e-7f2d-4745-a66d-9b96ae031c7a",
+  "mode": "live",
+  "type": "one_time",
+  "payment_type": "online",
+  "last_used_on" :  "2017-06-22T16:00:57.116321+09:00",
+  "created_on": "2017-06-22T16:00:55.436116+09:00",
+  "data": {
+    "gateway": "test",
+    "issuer_token" : "TOKEN",
+    "call_method" : "sdk"
+  }
+}

--- a/src/test/resources/responses/transactiontoken/post-online-no-email.json
+++ b/src/test/resources/responses/transactiontoken/post-online-no-email.json
@@ -1,0 +1,11 @@
+{
+  "id": "004b391f-1c98-43f8-87de-28b21aaaca00",
+  "store_id": "bf75472e-7f2d-4745-a66d-9b96ae031c7a",
+  "mode": "live",
+  "type": "one_time",
+  "created_on": "2017-06-22T16:00:55.436116+09:00",
+  "payment_type": "online",
+  "data": {
+    "gateway": "test"
+  }
+}

--- a/src/test/resources/serialization/online.json
+++ b/src/test/resources/serialization/online.json
@@ -1,0 +1,3 @@
+{
+  "gateway": "alipay_connect"
+}

--- a/src/test/resources/serialization/readme.md
+++ b/src/test/resources/serialization/readme.md
@@ -1,0 +1,3 @@
+### Json Read/Write samples
+
+This folder just keep simple samples to help to test GSON read/write mappings.


### PR DESCRIPTION
Added a way to create the transaction token with the PaymentType `Online` and it's payment data
Added in the `PaymentData` class, the fields for the `OnlinePaymentData` and the `asOnlinePaymentData()` implementation
Added a way to query the issuer token of the `Online`  by using the Charge Id, using the `getIssuerToken` route.
