### PR TITLE
Remove token login strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@
 *.iws
 *.class
 
+# VSCode
+.classpath
+.project
+.settings/
+bin/
+
 # Mac
 .DS_Store
 

--- a/src/main/java/com/univapay/sdk/UnivapaySDK.java
+++ b/src/main/java/com/univapay/sdk/UnivapaySDK.java
@@ -42,7 +42,6 @@ import com.univapay.sdk.models.common.auth.AppJWTStrategy;
 import com.univapay.sdk.models.common.auth.AppTokenStrategy;
 import com.univapay.sdk.models.common.auth.AuthStrategy;
 import com.univapay.sdk.models.common.auth.LoginJWTStrategy;
-import com.univapay.sdk.models.common.auth.LoginTokenStrategy;
 import com.univapay.sdk.models.common.auth.UnauthenticatedStrategy;
 import com.univapay.sdk.models.common.auth.UserCredentials;
 import com.univapay.sdk.models.common.bankaccounts.JapaneseBankAccount;
@@ -137,7 +136,6 @@ public class UnivapaySDK extends AbstractSDK implements SDKMethods<UnivapaySDK>,
    * @param settings The SDK settings.
    * @see AbstractSDKSettings
    * @see AuthStrategy
-   * @see LoginTokenStrategy
    * @see AppTokenStrategy
    * @see LoginJWTStrategy
    * @see AppJWTStrategy
@@ -172,7 +170,6 @@ public class UnivapaySDK extends AbstractSDK implements SDKMethods<UnivapaySDK>,
    * @param authStrategy The merchant's credentials.
    * @see AbstractSDKSettings
    * @see AuthStrategy
-   * @see LoginTokenStrategy
    * @see AppTokenStrategy
    * @see LoginJWTStrategy
    * @see AppJWTStrategy

--- a/src/main/java/com/univapay/sdk/models/response/authentication/LoginTokenInfo.java
+++ b/src/main/java/com/univapay/sdk/models/response/authentication/LoginTokenInfo.java
@@ -3,7 +3,6 @@ package com.univapay.sdk.models.response.authentication;
 import com.google.gson.annotations.SerializedName;
 import com.univapay.sdk.models.common.MerchantId;
 import com.univapay.sdk.models.common.auth.LoginJWTStrategy;
-import com.univapay.sdk.models.common.auth.LoginTokenStrategy;
 import com.univapay.sdk.models.response.UnivapayResponse;
 import java.util.UUID;
 
@@ -11,22 +10,11 @@ public class LoginTokenInfo extends UnivapayResponse {
   @SerializedName("jwt")
   private LoginJWTStrategy jwt;
 
-  @SerializedName("token")
-  private String token;
-
   @SerializedName("merchant_id")
   private UUID merchantId;
 
   public LoginJWTStrategy getJWTAuthStrategy() {
     return jwt;
-  }
-
-  public String getToken() {
-    return token;
-  }
-
-  public LoginTokenStrategy getLoginTokenAuthStrategy() {
-    return new LoginTokenStrategy(token);
   }
 
   public MerchantId getMerchantId() {

--- a/src/test/java/com/univapay/sdk/applicationtoken/CreateAppJWTTest.java
+++ b/src/test/java/com/univapay/sdk/applicationtoken/CreateAppJWTTest.java
@@ -1,6 +1,6 @@
 package com.univapay.sdk.applicationtoken;
-
 import static org.hamcrest.Matchers.*;
+
 import static org.junit.Assert.*;
 
 import com.google.common.collect.Sets;

--- a/src/test/java/com/univapay/sdk/applicationtoken/CreateAppTokenTest.java
+++ b/src/test/java/com/univapay/sdk/applicationtoken/CreateAppTokenTest.java
@@ -25,14 +25,14 @@ public class CreateAppTokenTest extends GenericTest {
   @Test
   public void shouldPostAppTokenDataAndReturnInfo() throws InterruptedException, ParseException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "POST",
         "/stores/bf75472e-7f2d-4745-a66d-9b96ae031c7a/app_tokens",
-        token,
+        jwt,
         200,
         StoreFakeRR.createStoreAppTokenFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
     List<Domain> reqDomains = new ArrayList<>();
     reqDomains.add(new Domain("www.test.com"));
 

--- a/src/test/java/com/univapay/sdk/applicationtoken/DeleteAppTokenTest.java
+++ b/src/test/java/com/univapay/sdk/applicationtoken/DeleteAppTokenTest.java
@@ -15,14 +15,14 @@ public class DeleteAppTokenTest extends GenericTest {
   @Test
   public void shouldRequestAppTokenDeletion() throws Exception {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "DELETE",
         "/stores/fbb48b8e-a443-45f7-9b7d-c278087f8060/app_tokens/90389195-ce76-43de-935b-7f1d417d23df",
-        token,
+        jwt,
         200,
         "{}");
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .deleteAppToken(

--- a/src/test/java/com/univapay/sdk/applicationtoken/GetAppTokenTest.java
+++ b/src/test/java/com/univapay/sdk/applicationtoken/GetAppTokenTest.java
@@ -23,17 +23,17 @@ public class GetAppTokenTest extends GenericTest {
   @Test
   public void shouldRequestAndReturnAppTokenInfo() throws InterruptedException, ParseException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/bf75472e-7f2d-4745-a66d-9b96ae031c7a/app_tokens",
-        token,
+        jwt,
         200,
         StoreFakeRR.getStoreAppTokenFakeResponse);
 
     final OffsetDateTime parsedDate =
         OffsetDateTime.parse("2017-06-22T16:00:55.436116+09:00", DateTimeFormatter.ISO_DATE_TIME);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .listAppTokens(new StoreId("bf75472e-7f2d-4745-a66d-9b96ae031c7a"))

--- a/src/test/java/com/univapay/sdk/applicationtoken/UpdateAppTokenTest.java
+++ b/src/test/java/com/univapay/sdk/applicationtoken/UpdateAppTokenTest.java
@@ -28,18 +28,18 @@ public class UpdateAppTokenTest extends GenericTest {
   public void shouldUpdateAndReturnAppTokenInfo()
       throws InterruptedException, IOException, ParseException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "PATCH",
         "/stores/bf75472e-7f2d-4745-a66d-9b96ae031c7a/"
             + "app_tokens/90389195-ce76-43de-935b-7f1d417d23df",
-        token,
+        jwt,
         200,
         StoreFakeRR.updateStoreAppTokenFakeResponse);
 
     final OffsetDateTime parsedCreatedOn =
         OffsetDateTime.parse("2017-06-22T16:00:55.436116+09:00", DateTimeFormatter.ISO_DATE_TIME);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     List<Domain> newDomains =
         Arrays.asList(new Domain("www.something.com"), new Domain("www.somethingelse.com"));

--- a/src/test/java/com/univapay/sdk/authentication/DeleteLoginTokenTest.java
+++ b/src/test/java/com/univapay/sdk/authentication/DeleteLoginTokenTest.java
@@ -14,9 +14,9 @@ public class DeleteLoginTokenTest extends GenericTest {
   @Test
   public void shouldRequestDeletionOfLoginToken() throws InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse("POST", "/logout", token, 200, "");
+    mockRRGenerator.GenerateMockRequestResponseJWT("POST", "/logout", jwt, 200, "");
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay.deleteLoginToken().build().dispatch(new ExpectSuccessCallback<Void>());
 

--- a/src/test/java/com/univapay/sdk/authentication/GetLoginTokenTest.java
+++ b/src/test/java/com/univapay/sdk/authentication/GetLoginTokenTest.java
@@ -17,7 +17,7 @@ public class GetLoginTokenTest extends GenericTest {
   @Test
   public void shouldRequestAndReturnLoginTokenInfo() throws Exception {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "POST",
         "/authenticate",
         null,
@@ -39,6 +39,5 @@ public class GetLoginTokenTest extends GenericTest {
     assertEquals(
         response.getJWTAuthStrategy().getToken(),
         "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJsb2dpbl90b2tlbiIsImV4cCI6MTUyMDQyMjU3MywiaWF0IjoxNTIwNDE4OTczLCJqdGkiOiIxMWU4MjFmMy01YmIxLTBmODYtOTcxZi0wMWRkOGYwOTFhN2QiLCJtZXJjaGFudF9pZCI6IjExZTgyMWJlLTY4ZDQtNzMwOC1iYjYwLWI3MmRhYzA4MTA5OCIsIm5hbWUiOiJSb290IEFkbWluIiwiZW1haWwiOiJyb290X2FkbWluQHVuaXZhcGF5LmNvbSIsImxhbmciOiJqYSIsImlwX2FkZHJlc3MiOiIwOjA6MDowOjA6MDowOjEiLCJhdWQiOiIxMWU4MjFiZS02NWY4LWMxZmMtYjdmNi1iYjQ4NzFiYmExN2EiLCJyb2xlcyI6WyJhZG1pbiJdfQ.iaypSYq2kM1iCsAhZiRIe8WiEiAkPWqRNX6KhcrT8fY");
-    assertEquals(response.getToken(), "quqhrNtsUY0ypKPbgfeO");
   }
 }

--- a/src/test/java/com/univapay/sdk/bankaccount/CreateBankAccountTest.java
+++ b/src/test/java/com/univapay/sdk/bankaccount/CreateBankAccountTest.java
@@ -28,15 +28,15 @@ public class CreateBankAccountTest extends GenericTest {
   public void shouldPostsAndReturnNewBankAccountInfo() throws InterruptedException, ParseException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "POST",
         "/bank_accounts",
-        token,
+        jwt,
         200,
         BankAccountsFakeRR.postBankAccountFakeResponseWithSwift,
         BankAccountsFakeRR.postBankAccountFakeRequestWithSwift);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate =
         OffsetDateTime.parse("2017-06-22T16:00:55.436116+09:00", DateTimeFormatter.ISO_DATE_TIME);

--- a/src/test/java/com/univapay/sdk/bankaccount/DeleteBankAccountTest.java
+++ b/src/test/java/com/univapay/sdk/bankaccount/DeleteBankAccountTest.java
@@ -16,10 +16,10 @@ public class DeleteBankAccountTest extends GenericTest {
   public void shouldRequestsDeletionOfBankAccount() throws InterruptedException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
-        "DELETE", "/bank_accounts/eb62d6c1-6b0b-40db-86d5-c631bd755bd6", token, 204, "{}");
+    mockRRGenerator.GenerateMockRequestResponseJWT(
+        "DELETE", "/bank_accounts/eb62d6c1-6b0b-40db-86d5-c631bd755bd6", jwt, 204, "{}");
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
     univapay
         .deleteBankAccount(new BankAccountId("eb62d6c1-6b0b-40db-86d5-c631bd755bd6"))
         .build()

--- a/src/test/java/com/univapay/sdk/bankaccount/GetBankAccountTest.java
+++ b/src/test/java/com/univapay/sdk/bankaccount/GetBankAccountTest.java
@@ -24,14 +24,14 @@ public class GetBankAccountTest extends GenericTest {
   public void shouldRequestAndReturnBankAccountInfo() throws InterruptedException, ParseException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/bank_accounts/6d50a40d-1785-42a6-9504-b003ce319851",
-        token,
+        jwt,
         200,
         BankAccountsFakeRR.getBankAccountFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate =
         OffsetDateTime.parse("2017-06-22T16:00:55.436116+09:00", DateTimeFormatter.ISO_DATE_TIME);

--- a/src/test/java/com/univapay/sdk/bankaccount/GetPrimaryBankAccountTest.java
+++ b/src/test/java/com/univapay/sdk/bankaccount/GetPrimaryBankAccountTest.java
@@ -24,14 +24,14 @@ public class GetPrimaryBankAccountTest extends GenericTest {
       throws InterruptedException, ParseException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/bank_accounts/primary",
-        token,
+        jwt,
         200,
         BankAccountsFakeRR.getPrimaryBankAccountFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate =
         OffsetDateTime.parse("2017-06-22T16:00:55.436116+09:00", DateTimeFormatter.ISO_DATE_TIME);

--- a/src/test/java/com/univapay/sdk/bankaccount/ListBankAccountsTest.java
+++ b/src/test/java/com/univapay/sdk/bankaccount/ListBankAccountsTest.java
@@ -24,10 +24,10 @@ public class ListBankAccountsTest extends GenericTest {
       throws InterruptedException, ParseException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
-        "GET", "/bank_accounts", token, 200, BankAccountsFakeRR.listAllBankAccountsFakeResponse);
+    mockRRGenerator.GenerateMockRequestResponseJWT(
+        "GET", "/bank_accounts", jwt, 200, BankAccountsFakeRR.listAllBankAccountsFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate =
         OffsetDateTime.parse("2017-06-22T16:00:55.436116+09:00", DateTimeFormatter.ISO_DATE_TIME);

--- a/src/test/java/com/univapay/sdk/bankaccount/UpdateBankAccountTest.java
+++ b/src/test/java/com/univapay/sdk/bankaccount/UpdateBankAccountTest.java
@@ -24,15 +24,15 @@ public class UpdateBankAccountTest extends GenericTest {
       throws InterruptedException, ParseException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "PATCH",
         "/bank_accounts/6d50a40d-1785-42a6-9504-b003ce319851",
-        token,
+        jwt,
         200,
         BankAccountsFakeRR.updateBankAccountFakeResponse,
         BankAccountsFakeRR.updatePostBankAccountFakeRequest);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate =
         OffsetDateTime.parse("2017-06-22T16:00:55.436116+09:00", DateTimeFormatter.ISO_DATE_TIME);

--- a/src/test/java/com/univapay/sdk/builders/RetrofitRequestBuilderTest.java
+++ b/src/test/java/com/univapay/sdk/builders/RetrofitRequestBuilderTest.java
@@ -67,14 +67,14 @@ public class RetrofitRequestBuilderTest extends GenericTest {
   @Test
   public void shouldPostWithDispatchMethodDirectly() throws InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/653ef5a3-73f2-408a-bac5-7058835f7700/charges/425e88b7-b588-4247-80ee-0ea0caff1190",
-        token,
+        jwt,
         200,
         ChargesFakeRR.getStoreChargeFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .getCharge(
@@ -101,14 +101,14 @@ public class RetrofitRequestBuilderTest extends GenericTest {
   public void shouldPostWithSynchronousDispatchMethodDirectly()
       throws IOException, UnivapayException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/653ef5a3-73f2-408a-bac5-7058835f7700/charges/425e88b7-b588-4247-80ee-0ea0caff1190",
-        token,
+        jwt,
         200,
         ChargesFakeRR.getStoreChargeFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .getCharge(
@@ -121,14 +121,14 @@ public class RetrofitRequestBuilderTest extends GenericTest {
   public void shouldPostWithRetryDispatchMethodDirectly()
       throws IOException, UnivapayException, InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/653ef5a3-73f2-408a-bac5-7058835f7700/charges/425e88b7-b588-4247-80ee-0ea0caff1190",
-        token,
+        jwt,
         200,
         ChargesFakeRR.getStoreChargeFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .getCharge(

--- a/src/test/java/com/univapay/sdk/charge/ChargeCompletionMonitorTest.java
+++ b/src/test/java/com/univapay/sdk/charge/ChargeCompletionMonitorTest.java
@@ -28,14 +28,14 @@ public class ChargeCompletionMonitorTest extends GenericTest {
   public void shouldRequestAndReturnChargeInfo()
       throws InterruptedException, UnivapayException, TimeoutException, IOException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/653ef5a3-73f2-408a-bac5-7058835f7700/charges/425e88b7-b588-4247-80ee-0ea0caff1190?polling=true",
-        token,
+        jwt,
         200,
         ChargesFakeRR.getStoreChargeFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     ResourceMonitor<Charge> monitor =
         univapay.chargeCompletionMonitor(
@@ -50,14 +50,14 @@ public class ChargeCompletionMonitorTest extends GenericTest {
   public void shouldRequestAndReturnChargeInfoAsync()
       throws InterruptedException, UnivapayException, TimeoutException, IOException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/653ef5a3-73f2-408a-bac5-7058835f7700/charges/425e88b7-b588-4247-80ee-0ea0caff1190?polling=true",
-        token,
+        jwt,
         200,
         ChargesFakeRR.getStoreChargeFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     ResourceMonitor<Charge> monitor =
         univapay.chargeCompletionMonitor(

--- a/src/test/java/com/univapay/sdk/charge/GetChargeTest.java
+++ b/src/test/java/com/univapay/sdk/charge/GetChargeTest.java
@@ -24,14 +24,14 @@ public class GetChargeTest extends GenericTest {
   @Test
   public void shouldRequestAndReturnChargeInfo() throws InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/653ef5a3-73f2-408a-bac5-7058835f7700/charges/425e88b7-b588-4247-80ee-0ea0caff1190",
-        token,
+        jwt,
         200,
         ChargesFakeRR.getStoreChargeFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .getCharge(

--- a/src/test/java/com/univapay/sdk/charge/ListChargesTest.java
+++ b/src/test/java/com/univapay/sdk/charge/ListChargesTest.java
@@ -23,14 +23,14 @@ public class ListChargesTest extends GenericTest {
   @Test
   public void shouldRequestAndReturnListOfCharges() throws InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/653ef5a3-73f2-408a-bac5-7058835f7700/charges",
-        token,
+        jwt,
         200,
         ChargesFakeRR.listAllStoreChargesFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .listCharges(new StoreId("653ef5a3-73f2-408a-bac5-7058835f7700"))
@@ -80,8 +80,8 @@ public class ListChargesTest extends GenericTest {
     //                "email=some@email.com&metadata=skate%20board";
     //
     //        MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    //        mockRRGenerator.GenerateMockRequestResponse("GET",fullPath,
-    //                token, 200, "{\n" +
+    //        mockRRGenerator.GenerateMockRequestResponseJWT("GET",fullPath,
+    //                jwt, 200, "{\n" +
     //                        "    \"items\": [],\n" +
     //                        "    \"has_more\": false\n" +
     //                        "}");

--- a/src/test/java/com/univapay/sdk/charge/UpdateChargeTest.java
+++ b/src/test/java/com/univapay/sdk/charge/UpdateChargeTest.java
@@ -33,15 +33,15 @@ public class UpdateChargeTest extends GenericTest {
   @Test
   public void shouldPostAndReturnUpdatedChargeInfo() throws InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "PATCH",
         "/stores/11e786da-4714-5028-8280-bb9bc7cf54e9/charges/11e792d6-6e0c-bf1e-bede-0be6e2f0ac23",
-        token,
+        jwt,
         200,
         ChargesFakeRR.updateStoreChargeFakeResponse,
         ChargesFakeRR.updateStoreChargeFakeRequest);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedCreatedOn = parseDate("2017-09-06T07:38:52.000000+09:00");
     final OffsetDateTime parsedUpdatedOn = parseDate("2017-10-02T06:25:06.000000+09:00");

--- a/src/test/java/com/univapay/sdk/client/ClientTest.java
+++ b/src/test/java/com/univapay/sdk/client/ClientTest.java
@@ -29,14 +29,14 @@ public class ClientTest {
     public void shouldCloneClientSharingThreadPool() throws Exception {
 
       MockRRGenerator mockRRGenerator = new MockRRGenerator();
-      mockRRGenerator.GenerateMockRequestResponse(
-          "GET", "/stores", token, 200, StoreFakeRR.listAllStoresFakeResponse);
+      mockRRGenerator.GenerateMockRequestResponseJWT(
+          "GET", "/stores", jwt, 200, StoreFakeRR.listAllStoresFakeResponse);
 
       final int iterations = 50;
 
       final int initialThreads = countOkHttpThreadPools();
 
-      final UnivapaySDK firstClient = createTestInstance(AuthType.LOGIN_TOKEN);
+      final UnivapaySDK firstClient = createTestInstance(AuthType.JWT);
       List<UnivapaySDK> clients = new ArrayList<>();
       clients.add(firstClient);
 
@@ -66,14 +66,14 @@ public class ClientTest {
       Logger logger = Logger.getLogger(this.getClass().getName());
 
       MockRRGenerator mockRRGenerator = new MockRRGenerator();
-      mockRRGenerator.GenerateMockRequestResponse(
-          "GET", "/stores", token, 200, StoreFakeRR.listAllStoresFakeResponse);
+      mockRRGenerator.GenerateMockRequestResponseJWT(
+          "GET", "/stores", jwt, 200, StoreFakeRR.listAllStoresFakeResponse);
 
       final int iterations = 50;
       final int initialThreads = countOkHttpThreadPools();
       final int expectedThreads = initialThreads + iterations;
 
-      final UnivapaySDK firstClient = createTestInstance(AuthType.LOGIN_TOKEN);
+      final UnivapaySDK firstClient = createTestInstance(AuthType.JWT);
       List<UnivapaySDK> clients = new ArrayList<>();
       clients.add(firstClient);
 

--- a/src/test/java/com/univapay/sdk/errors/ValidationErrorsTest.java
+++ b/src/test/java/com/univapay/sdk/errors/ValidationErrorsTest.java
@@ -17,7 +17,7 @@ public class ValidationErrorsTest extends GenericTest {
   @Test(expected = IllegalArgumentException.class)
   public void shouldParseValidationErrorsSuccessfully() throws IOException, UnivapayException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "POST",
         "/authenticate",
         null,
@@ -25,7 +25,7 @@ public class ValidationErrorsTest extends GenericTest {
         ErrorsFakeRR.invalidFormatFakeResponse,
         ErrorsFakeRR.invalidFormatFakeRequest);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay.getLoginToken("newaccount", "c").build().dispatch();
   }
@@ -33,9 +33,9 @@ public class ValidationErrorsTest extends GenericTest {
   @Test
   public void shouldHandleAnEmptyResponseBody() throws Exception {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse("GET", "/stores", null, 520, "{}");
+    mockRRGenerator.GenerateMockRequestResponseJWT("GET", "/stores", null, 520, "{}");
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
     try {
       univapay.listStores().build().dispatch();
     } catch (UnivapayException e) {
@@ -47,9 +47,9 @@ public class ValidationErrorsTest extends GenericTest {
   @Test
   public void shouldHandleAnNullBody() throws Exception {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse("GET", "/stores", null, 401, (String) null);
+    mockRRGenerator.GenerateMockRequestResponseJWT("GET", "/stores", null, 401, (String) null);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
     try {
       univapay.listStores().build().dispatch();
     } catch (UnivapayException e) {

--- a/src/test/java/com/univapay/sdk/ledger/ListLedgersTest.java
+++ b/src/test/java/com/univapay/sdk/ledger/ListLedgersTest.java
@@ -25,14 +25,14 @@ public class ListLedgersTest extends GenericTest {
   public void shouldRequestListOfLedgers() throws InterruptedException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/transfers/8e5269b8-ec32-11e6-88ca-fb17c7a225eb/ledgers",
-        token,
+        jwt,
         204,
         LedgersFakeRR.getMerchantBalanceFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .listLedgers(new TransferId("8e5269b8-ec32-11e6-88ca-fb17c7a225eb"))
@@ -47,14 +47,14 @@ public class ListLedgersTest extends GenericTest {
   @Test
   public void shouldReturnListOfLedgers() throws InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/transfers/8e5269b8-ec32-11e6-88ca-fb17c7a225eb/ledgers",
-        token,
+        jwt,
         200,
         LedgersFakeRR.getMerchantBalanceFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .listLedgers(new TransferId("8e5269b8-ec32-11e6-88ca-fb17c7a225eb"))
@@ -94,14 +94,14 @@ public class ListLedgersTest extends GenericTest {
   public void shouldRequestListOfLedgersWithQueryParams() throws InterruptedException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/transfers/8e5269b8-ec32-11e6-88ca-fb17c7a225eb/ledgers?all=true&currency=JPY",
-        token,
+        jwt,
         204,
         LedgersFakeRR.getMerchantBalanceFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .listLedgers(new TransferId("8e5269b8-ec32-11e6-88ca-fb17c7a225eb"))

--- a/src/test/java/com/univapay/sdk/merchant/CreateMerchantVerificationTest.java
+++ b/src/test/java/com/univapay/sdk/merchant/CreateMerchantVerificationTest.java
@@ -27,14 +27,14 @@ public class CreateMerchantVerificationTest extends GenericTest {
       throws InterruptedException, IOException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "POST",
         "/verification",
-        token,
+        jwt,
         200,
         MerchantsFakeRR.postMerchantVerificationFakeResponse,
         MerchantsFakeRR.postMerchantVerificationFakeRequest);
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final MerchantCompanyContactInfo contactInfo =
         new MerchantCompanyContactInfo(
@@ -91,14 +91,14 @@ public class CreateMerchantVerificationTest extends GenericTest {
   public void shouldPostLegacyCountry() throws InterruptedException, IOException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "POST",
         "/verification",
-        token,
+        jwt,
         200,
         MerchantsFakeRR.postMerchantVerificationFakeResponse,
         MerchantsFakeRR.postMerchantVerificationFakeRequest);
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final MerchantCompanyContactInfo contactInfo =
         new MerchantCompanyContactInfo(

--- a/src/test/java/com/univapay/sdk/merchant/GetMeTest.java
+++ b/src/test/java/com/univapay/sdk/merchant/GetMeTest.java
@@ -45,9 +45,9 @@ public class GetMeTest extends GenericTest {
   public void shouldRequestAndReturnMerchantInfo() throws Exception {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
-        "GET", "/me", token, 200, JsonLoader.loadJson("responses/me/sample-me.json"));
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    mockRRGenerator.GenerateMockRequestResponseJWT(
+        "GET", "/me", jwt, 200, JsonLoader.loadJson("responses/me/sample-me.json"));
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate = parseDate("2017-06-22T16:00:55.436116+09:00");
 

--- a/src/test/java/com/univapay/sdk/merchant/GetMerchantTransactionHistoryTest.java
+++ b/src/test/java/com/univapay/sdk/merchant/GetMerchantTransactionHistoryTest.java
@@ -21,13 +21,13 @@ public class GetMerchantTransactionHistoryTest extends GenericTest {
   public void shouldRequestAndReturnMerchantVerificationData() throws InterruptedException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/transaction_history",
-        token,
+        jwt,
         200,
         MerchantsFakeRR.getMerchantTransactionHistoryFakeResponse);
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .getTransactionHistory()

--- a/src/test/java/com/univapay/sdk/merchant/GetMerchantVerificationTest.java
+++ b/src/test/java/com/univapay/sdk/merchant/GetMerchantVerificationTest.java
@@ -27,9 +27,9 @@ public class GetMerchantVerificationTest extends GenericTest {
       throws InterruptedException, IOException, ParseException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
-        "GET", "/verification", token, 200, MerchantsFakeRR.getMerchantVerificationFakeResponse);
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    mockRRGenerator.GenerateMockRequestResponseJWT(
+        "GET", "/verification", jwt, 200, MerchantsFakeRR.getMerchantVerificationFakeResponse);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate = parseDate("2017-06-22T16:00:55.436116+09:00");
 

--- a/src/test/java/com/univapay/sdk/merchant/GetTransactionHistoryTest.java
+++ b/src/test/java/com/univapay/sdk/merchant/GetTransactionHistoryTest.java
@@ -34,13 +34,13 @@ public class GetTransactionHistoryTest extends GenericTest {
   public void shouldRequestAndReturnTransactionHistory() throws InterruptedException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/45facc11-efc8-4156-8ef3-e363a70a54c3/transaction_history",
-        token,
+        jwt,
         200,
         MerchantsFakeRR.getStoreTransactionHistoryFakeResponse);
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate = parseDate("2017-06-22T16:00:55.436116+09:00");
 
@@ -294,18 +294,18 @@ public class GetTransactionHistoryTest extends GenericTest {
     final OffsetDateTime parsedDate = parseDate("2017-06-22T16:00:55.436116+09:00");
     final String dateString = urlEncode(formatDate(parsedDate));
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/45facc11-efc8-4156-8ef3-e363a70a54c3/transaction_history?from="
             + dateString
             + "&to="
             + dateString
             + "&status=successful&type=charge&mode=test&search=search&all=true",
-        token,
+        jwt,
         200,
         MerchantsFakeRR.getStoreTransactionHistoryFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .getTransactionHistory(new StoreId("45facc11-efc8-4156-8ef3-e363a70a54c3"))

--- a/src/test/java/com/univapay/sdk/merchant/UpdateMerchantVerificationTest.java
+++ b/src/test/java/com/univapay/sdk/merchant/UpdateMerchantVerificationTest.java
@@ -25,14 +25,14 @@ public class UpdateMerchantVerificationTest extends GenericTest {
       throws InterruptedException, IOException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "PATCH",
         "/verification",
-        token,
+        jwt,
         200,
         MerchantsFakeRR.updateMerchantVerificationFakeResponse,
         MerchantsFakeRR.updateMerchantVerificationFakeRequest);
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .updateMerchantVerification()
@@ -87,14 +87,14 @@ public class UpdateMerchantVerificationTest extends GenericTest {
   public void shouldUpdateLegacyCountry() throws InterruptedException, IOException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "PATCH",
         "/verification",
-        token,
+        jwt,
         200,
         MerchantsFakeRR.updateMerchantVerificationFakeResponse,
         MerchantsFakeRR.updateMerchantVerificationFakeRequest);
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .updateMerchantVerification()
@@ -132,14 +132,14 @@ public class UpdateMerchantVerificationTest extends GenericTest {
   public void shouldRemoveEmailFromMerchantVerificationData() throws InterruptedException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "PATCH",
         "/verification",
-        token,
+        jwt,
         200,
         MerchantsFakeRR.updateMerchantVerificationFakeResponse,
         MerchantsFakeRR.updateMerchantVerificationWithEmptyEmailFakeRequest);
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .updateMerchantVerification()

--- a/src/test/java/com/univapay/sdk/models/response/PaginatedListTest.java
+++ b/src/test/java/com/univapay/sdk/models/response/PaginatedListTest.java
@@ -73,10 +73,10 @@ public class PaginatedListTest extends GenericTest {
   @Test(expected = UnsupportedOperationException.class)
   public void shouldThrowIfChangeItems() {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
-        "GET", "/stores", token, 200, StoreFakeRR.listAllStoresPaginationParamFakeResponse);
+    mockRRGenerator.GenerateMockRequestResponseJWT(
+        "GET", "/stores", jwt, 200, StoreFakeRR.listAllStoresPaginationParamFakeResponse);
 
-    UnivapaySDK payments = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK payments = createTestInstance(AuthType.JWT);
 
     PaginatedListIterable<Store> iterable = payments.listStores().asIterable();
     iterable.getPaginatedList().getItems().add(new Store());

--- a/src/test/java/com/univapay/sdk/pagination/BankaccountsPaginationTest.java
+++ b/src/test/java/com/univapay/sdk/pagination/BankaccountsPaginationTest.java
@@ -17,14 +17,14 @@ public class BankaccountsPaginationTest extends GenericTest {
   public void shouldRequestBankAccountsWithPaginationParams() throws InterruptedException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/bank_accounts?limit=4&cursor_direction=asc&cursor=6692a026-f2f6-499e-9d90-abd957bc89d8",
-        token,
+        jwt,
         200,
         BankAccountsFakeRR.listAllBankAccountsFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .listBankAccounts()
@@ -40,10 +40,10 @@ public class BankaccountsPaginationTest extends GenericTest {
   @Test
   public void shouldRequestNext() {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
-        "GET", "/bank_accounts", token, 200, BankAccountsFakeRR.listAllBankAccountsFakeResponse);
+    mockRRGenerator.GenerateMockRequestResponseJWT(
+        "GET", "/bank_accounts", jwt, 200, BankAccountsFakeRR.listAllBankAccountsFakeResponse);
 
-    UnivapaySDK payments = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK payments = createTestInstance(AuthType.JWT);
 
     payments.listBankAccounts().asIterable().iterator().next();
   }

--- a/src/test/java/com/univapay/sdk/pagination/ChargesPaginationTest.java
+++ b/src/test/java/com/univapay/sdk/pagination/ChargesPaginationTest.java
@@ -16,14 +16,14 @@ public class ChargesPaginationTest extends GenericTest {
   @Test
   public void shouldRequestChargesWithPaginationParams() throws InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/653ef5a3-73f2-408a-bac5-7058835f7700/charges?limit=2&cursor_direction=desc&cursor=e544b386-b13c-42c9-ab77-b36f95c99eab",
-        token,
+        jwt,
         200,
         ChargesFakeRR.listAllStoreChargesFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .listCharges(new StoreId("653ef5a3-73f2-408a-bac5-7058835f7700"))
@@ -39,14 +39,14 @@ public class ChargesPaginationTest extends GenericTest {
   @Test
   public void shouldRequestNext() {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/653ef5a3-73f2-408a-bac5-7058835f7700/charges",
-        token,
+        jwt,
         200,
         ChargesFakeRR.listAllStoreChargesFakeResponse);
 
-    UnivapaySDK payments = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK payments = createTestInstance(AuthType.JWT);
 
     payments
         .listCharges(new StoreId("653ef5a3-73f2-408a-bac5-7058835f7700"))

--- a/src/test/java/com/univapay/sdk/pagination/LedgersPaginationTest.java
+++ b/src/test/java/com/univapay/sdk/pagination/LedgersPaginationTest.java
@@ -21,14 +21,14 @@ public class LedgersPaginationTest extends GenericTest {
       throws IOException, UnivapayException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/transfers/8e5269b8-ec32-11e6-88ca-fb17c7a225eb/ledgers?limit=20&cursor_direction=asc&cursor=f8c86f7a-18f3-11e7-93ff-6feb8d2883ae",
-        token,
+        jwt,
         204,
         "{}");
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .listLedgers(new TransferId("8e5269b8-ec32-11e6-88ca-fb17c7a225eb"))
@@ -47,14 +47,14 @@ public class LedgersPaginationTest extends GenericTest {
   @Test
   public void shouldRequestNext() {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/transfers/653ef5a3-73f2-408a-bac5-7058835f7700/ledgers",
-        token,
+        jwt,
         200,
         LedgersFakeRR.listLedgersFakeResponse);
 
-    UnivapaySDK payments = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK payments = createTestInstance(AuthType.JWT);
 
     payments
         .listLedgers(new TransferId("653ef5a3-73f2-408a-bac5-7058835f7700"))

--- a/src/test/java/com/univapay/sdk/pagination/PaginatedListIterableTest.java
+++ b/src/test/java/com/univapay/sdk/pagination/PaginatedListIterableTest.java
@@ -27,17 +27,17 @@ public class PaginatedListIterableTest extends GenericTest {
   @Test
   public void shouldRequestIterableStores() {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores?limit=2&cursor_direction=desc",
-        token,
+        jwt,
         200,
         new PaginatedMock(StoresMock.storesMock));
 
     final OffsetDateTime parsedDate =
         OffsetDateTime.parse("2018-02-27T17:00:43.476016+09:00", DateTimeFormatter.ISO_DATE_TIME);
 
-    UnivapaySDK payments = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK payments = createTestInstance(AuthType.JWT);
 
     PaginatedListIterable<Store> iterable =
         payments.listStores().setLimit(2).setCursorDirection(CursorDirection.DESC).asIterable();
@@ -50,10 +50,10 @@ public class PaginatedListIterableTest extends GenericTest {
         onePage.add(store);
         i++;
         if (i == 2) {
-          mockRRGenerator.GenerateMockRequestResponse(
+          mockRRGenerator.GenerateMockRequestResponseJWT(
               "GET",
               "/stores?limit=2&cursor_direction=desc&cursor=8486dc98-9836-41dd-b598-bbf49d5bc861",
-              token,
+              jwt,
               200,
               new PaginatedMock(StoresMock.storesMock));
         }
@@ -80,16 +80,16 @@ public class PaginatedListIterableTest extends GenericTest {
   @Test
   public void shouldRequestIterableStoresReverse() {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores?limit=2&cursor_direction=asc",
-        token,
+        jwt,
         200,
         new PaginatedMock(StoresMock.storesMock));
     final OffsetDateTime parsedDate =
         OffsetDateTime.parse("2018-02-27T17:00:43.476016+09:00", DateTimeFormatter.ISO_DATE_TIME);
 
-    UnivapaySDK payments = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK payments = createTestInstance(AuthType.JWT);
 
     PaginatedListIterable<Store> iterable =
         payments.listStores().setLimit(2).setCursorDirection(CursorDirection.DESC).asIterable();
@@ -103,10 +103,10 @@ public class PaginatedListIterableTest extends GenericTest {
         onePage.add(store);
         i++;
         if (i == 2) {
-          mockRRGenerator.GenerateMockRequestResponse(
+          mockRRGenerator.GenerateMockRequestResponseJWT(
               "GET",
               "/stores?limit=2&cursor_direction=asc&cursor=8486dc98-9836-41dd-b598-bbf49d5bc861",
-              token,
+              jwt,
               200,
               new PaginatedMock(StoresMock.storesMock));
         }
@@ -133,16 +133,16 @@ public class PaginatedListIterableTest extends GenericTest {
   @Test
   public void shouldRequestIterableStoresReverseInMiddle() {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores?limit=1&cursor_direction=desc&cursor=11e81b94-4f52-1398-8ab3-230675bcb38f",
-        token,
+        jwt,
         200,
         new PaginatedMock(StoresMock.storesMock));
     final OffsetDateTime parsedDate =
         OffsetDateTime.parse("2018-02-27T17:00:43.476016+09:00", DateTimeFormatter.ISO_DATE_TIME);
 
-    UnivapaySDK payments = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK payments = createTestInstance(AuthType.JWT);
 
     PaginatedListIterable<Store> iterable =
         payments
@@ -156,18 +156,18 @@ public class PaginatedListIterableTest extends GenericTest {
     UnivapayPaginatedListIterator<Store> iterator = iterable.iterator();
     actual.add(iterator.next());
     iterator.reverse();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores?limit=1&cursor_direction=asc&cursor=8486dc98-9836-41dd-b598-bbf49d5bc861",
-        token,
+        jwt,
         200,
         new PaginatedMock(StoresMock.storesMock));
     actual.add(iterator.next());
     iterator.reverse();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores?limit=1&cursor_direction=desc&cursor=11e81b94-4f52-1398-8ab3-230675bcb38f",
-        token,
+        jwt,
         200,
         new PaginatedMock(StoresMock.storesMock));
     actual.add(iterator.next());
@@ -191,16 +191,16 @@ public class PaginatedListIterableTest extends GenericTest {
   @Test
   public void shouldRequestIterableStoresReverseIterable() {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores?limit=2&cursor_direction=asc",
-        token,
+        jwt,
         200,
         new PaginatedMock(StoresMock.storesMock));
     final OffsetDateTime parsedDate =
         OffsetDateTime.parse("2018-02-27T17:00:43.476016+09:00", DateTimeFormatter.ISO_DATE_TIME);
 
-    UnivapaySDK payments = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK payments = createTestInstance(AuthType.JWT);
 
     PaginatedListIterable<Store> iterable =
         payments.listStores().setLimit(2).setCursorDirection(CursorDirection.DESC).asIterable();
@@ -214,10 +214,10 @@ public class PaginatedListIterableTest extends GenericTest {
         onePage.add(store);
         i++;
         if (i == 2) {
-          mockRRGenerator.GenerateMockRequestResponse(
+          mockRRGenerator.GenerateMockRequestResponseJWT(
               "GET",
               "/stores?limit=2&cursor_direction=asc&cursor=8486dc98-9836-41dd-b598-bbf49d5bc861",
-              token,
+              jwt,
               200,
               new PaginatedMock(StoresMock.storesMock));
         }
@@ -244,10 +244,10 @@ public class PaginatedListIterableTest extends GenericTest {
   @Test(expected = UnsupportedOperationException.class)
   public void shouldThrownUnsupportedExceptionWithoutAsIterable() {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores?limit=1&cursor_direction=desc&cursor=11e81b94-4f52-1398-8ab3-230675bcb38f",
-        token,
+        jwt,
         200,
         new PaginatedMock(StoresMock.storesMock));
 

--- a/src/test/java/com/univapay/sdk/pagination/RefundsPaginationTest.java
+++ b/src/test/java/com/univapay/sdk/pagination/RefundsPaginationTest.java
@@ -17,16 +17,16 @@ public class RefundsPaginationTest extends GenericTest {
   @Test
   public void shouldRequestRefundsWithPaginationParams() throws InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/653ef5a3-73f2-408a-bac5-7058835f7700/charges"
             + "/6791acdd-d901-49b8-a46f-24a7a39e894f/refunds"
             + "?limit=2&cursor_direction=desc&cursor=04ea4e3e-3f19-43d3-8593-fed3aba06771",
-        token,
+        jwt,
         200,
         ChargesFakeRR.listAllRefundsFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .listRefunds(
@@ -44,15 +44,15 @@ public class RefundsPaginationTest extends GenericTest {
   @Test
   public void shouldRequestNext() {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/653ef5a3-73f2-408a-bac5-7058835f7700/charges"
             + "/6791acdd-d901-49b8-a46f-24a7a39e894f/refunds",
-        token,
+        jwt,
         200,
         ChargesFakeRR.listAllRefundsFakeResponse);
 
-    UnivapaySDK payments = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK payments = createTestInstance(AuthType.JWT);
 
     payments
         .listRefunds(

--- a/src/test/java/com/univapay/sdk/pagination/StoresPaginationTest.java
+++ b/src/test/java/com/univapay/sdk/pagination/StoresPaginationTest.java
@@ -19,14 +19,14 @@ public class StoresPaginationTest extends GenericTest {
   @Test
   public void shouldRequestStoresWithPaginationParams() throws InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores?limit=2&cursor_direction=desc&cursor=8486dc98-9836-41dd-b598-bbf49d5bc862",
-        token,
+        jwt,
         200,
         StoreFakeRR.listAllStoresPaginationParamFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .listStores()
@@ -54,10 +54,10 @@ public class StoresPaginationTest extends GenericTest {
   @Test
   public void shouldRequestNext() {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
-        "GET", "/stores", token, 200, StoreFakeRR.listAllStoresPaginationParamFakeResponse);
+    mockRRGenerator.GenerateMockRequestResponseJWT(
+        "GET", "/stores", jwt, 200, StoreFakeRR.listAllStoresPaginationParamFakeResponse);
 
-    UnivapaySDK payments = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK payments = createTestInstance(AuthType.JWT);
 
     payments.listStores().asIterable().iterator().next();
   }

--- a/src/test/java/com/univapay/sdk/pagination/SubscriptionsPaginationTest.java
+++ b/src/test/java/com/univapay/sdk/pagination/SubscriptionsPaginationTest.java
@@ -17,14 +17,14 @@ public class SubscriptionsPaginationTest extends GenericTest {
   @Test
   public void shouldRequestSubscriptionsWithPaginationParams() throws InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/45facc11-efc8-4156-8ef3-e363a70a54c3/subscriptions?limit=1&cursor_direction=desc&cursor=714498e7-5031-4d48-b2ac-9bad8a8a4142",
-        token,
+        jwt,
         200,
         ChargesFakeRR.listAllStoreSubscriptionsFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .listSubscriptions(new StoreId("45facc11-efc8-4156-8ef3-e363a70a54c3"))
@@ -40,14 +40,14 @@ public class SubscriptionsPaginationTest extends GenericTest {
   @Test
   public void shouldRequestNext() {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/45facc11-efc8-4156-8ef3-e363a70a54c3/subscriptions",
-        token,
+        jwt,
         200,
         ChargesFakeRR.listAllStoreSubscriptionsFakeResponse);
 
-    UnivapaySDK payments = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK payments = createTestInstance(AuthType.JWT);
 
     payments
         .listSubscriptions(new StoreId("45facc11-efc8-4156-8ef3-e363a70a54c3"))

--- a/src/test/java/com/univapay/sdk/pagination/TransactionHistoryPaginationTest.java
+++ b/src/test/java/com/univapay/sdk/pagination/TransactionHistoryPaginationTest.java
@@ -20,13 +20,13 @@ public class TransactionHistoryPaginationTest extends GenericTest {
   public void shouldRequestTransactionHistoryWithPaginationParams() throws InterruptedException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/45facc11-efc8-4156-8ef3-e363a70a54c3/transaction_history?limit=3&cursor_direction=asc&cursor=e1771339-b989-4a43-99c1-5e35d8008427",
-        token,
+        jwt,
         200,
         MerchantsFakeRR.getStoreTransactionHistoryFakeResponse);
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .getTransactionHistory(new StoreId("45facc11-efc8-4156-8ef3-e363a70a54c3"))
@@ -54,14 +54,14 @@ public class TransactionHistoryPaginationTest extends GenericTest {
   @Test
   public void shouldRequestNext() {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/45facc11-efc8-4156-8ef3-e363a70a54c3/transaction_history",
-        token,
+        jwt,
         200,
         MerchantsFakeRR.getStoreTransactionHistoryFakeResponse);
 
-    UnivapaySDK payments = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK payments = createTestInstance(AuthType.JWT);
 
     payments
         .getTransactionHistory(new StoreId("45facc11-efc8-4156-8ef3-e363a70a54c3"))

--- a/src/test/java/com/univapay/sdk/pagination/TransfersPaginationTest.java
+++ b/src/test/java/com/univapay/sdk/pagination/TransfersPaginationTest.java
@@ -15,14 +15,14 @@ public class TransfersPaginationTest extends GenericTest {
   @Test
   public void shouldRequestTransfersWithPaginationParams() throws InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/transfers?limit=1&cursor_direction=asc&cursor=45f1a7ac-903e-4c46-a959-5564f4fdc5cb",
-        token,
+        jwt,
         200,
         TransfersFakeRR.listAllTransfersFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .listTransfers()
@@ -38,10 +38,10 @@ public class TransfersPaginationTest extends GenericTest {
   @Test
   public void shouldRequestNext() {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
-        "GET", "/transfers", token, 200, TransfersFakeRR.listAllTransfersFakeResponse);
+    mockRRGenerator.GenerateMockRequestResponseJWT(
+        "GET", "/transfers", jwt, 200, TransfersFakeRR.listAllTransfersFakeResponse);
 
-    UnivapaySDK payments = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK payments = createTestInstance(AuthType.JWT);
 
     payments.listTransfers().asIterable().iterator().next();
   }

--- a/src/test/java/com/univapay/sdk/pagination/WebhooksPaginationTest.java
+++ b/src/test/java/com/univapay/sdk/pagination/WebhooksPaginationTest.java
@@ -16,14 +16,14 @@ public class WebhooksPaginationTest extends GenericTest {
   @Test
   public void shouldRequestWebhooksWithPaginationParams() throws InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/8486dc98-9836-41dd-b598-bbf49d5bc861/webhooks?limit=2&cursor_direction=desc&cursor=9a363dc6-ce7d-4b6d-af5b-b92aebd0bf41",
-        token,
+        jwt,
         200,
         StoreFakeRR.listAllStoreWebhooksResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .listWebhooks(new StoreId("8486dc98-9836-41dd-b598-bbf49d5bc861"))
@@ -39,14 +39,14 @@ public class WebhooksPaginationTest extends GenericTest {
   @Test
   public void shouldRequestNext() {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/8486dc98-9836-41dd-b598-bbf49d5bc861/webhooks",
-        token,
+        jwt,
         200,
         StoreFakeRR.listAllStoreWebhooksResponse);
 
-    UnivapaySDK payments = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK payments = createTestInstance(AuthType.JWT);
 
     payments
         .listWebhooks(new StoreId("8486dc98-9836-41dd-b598-bbf49d5bc861"))

--- a/src/test/java/com/univapay/sdk/refund/CreateRefundTest.java
+++ b/src/test/java/com/univapay/sdk/refund/CreateRefundTest.java
@@ -35,15 +35,15 @@ public class CreateRefundTest extends GenericTest {
   @Test
   public void shouldPostAndReturnRefundData() throws InterruptedException, ParseException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "POST",
         "/stores/653ef5a3-73f2-408a-bac5-7058835f7700/charges/6791acdd-d901-49b8-a46f-24a7a39e894f/refunds",
-        token,
+        jwt,
         201,
         ChargesFakeRR.createRefundFakeResponse,
         ChargesFakeRR.createRefundFakeRequest);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     MetadataMap reqMetadata = new MetadataMap();
     reqMetadata.put("cod", String.valueOf(504547895));
@@ -128,15 +128,15 @@ public class CreateRefundTest extends GenericTest {
   @Test
   public void CreateRefundWithoutMetadataTest() throws InterruptedException, ParseException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "POST",
         "/stores/653ef5a3-73f2-408a-bac5-7058835f7700/charges/6791acdd-d901-49b8-a46f-24a7a39e894f/refunds",
-        token,
+        jwt,
         201,
         ChargesFakeRR.createRefundWithoutMetadataFakeResponse,
         ChargesFakeRR.createRefundWithoutMetadataFakeRequest);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate =
         OffsetDateTime.parse("2017-06-22T16:00:55.436116+09:00", DateTimeFormatter.ISO_DATE_TIME);

--- a/src/test/java/com/univapay/sdk/refund/GetRefundTest.java
+++ b/src/test/java/com/univapay/sdk/refund/GetRefundTest.java
@@ -28,15 +28,15 @@ public class GetRefundTest extends GenericTest {
   @Test
   public void shouldRequestAndReturnRefundInfo() throws InterruptedException, ParseException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/653ef5a3-73f2-408a-bac5-7058835f7700/charges/"
             + "6791acdd-d901-49b8-a46f-24a7a39e894f/refunds/45f1a7ac-903e-4c46-a959-5564f4fdc5ca",
-        token,
+        jwt,
         200,
         ChargesFakeRR.getRefundFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate =
         OffsetDateTime.parse("2017-06-22T16:00:55.436116+09:00", DateTimeFormatter.ISO_DATE_TIME);

--- a/src/test/java/com/univapay/sdk/refund/ListRefundsTest.java
+++ b/src/test/java/com/univapay/sdk/refund/ListRefundsTest.java
@@ -22,15 +22,15 @@ public class ListRefundsTest extends GenericTest {
   @Test
   public void shouldRequestAndReturnListOfRefunds() throws InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/653ef5a3-73f2-408a-bac5-7058835f7700/charges"
             + "/6791acdd-d901-49b8-a46f-24a7a39e894f/refunds",
-        token,
+        jwt,
         200,
         ChargesFakeRR.listAllRefundsFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .listRefunds(
@@ -71,10 +71,10 @@ public class ListRefundsTest extends GenericTest {
             + "/6791acdd-d901-49b8-a46f-24a7a39e894f/refunds?metadata=surf%20board";
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
-        "GET", fullPath, token, 200, ChargesFakeRR.listAllRefundsFakeResponse);
+    mockRRGenerator.GenerateMockRequestResponseJWT(
+        "GET", fullPath, jwt, 200, ChargesFakeRR.listAllRefundsFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .listRefunds(

--- a/src/test/java/com/univapay/sdk/store/CreateStoreTest.java
+++ b/src/test/java/com/univapay/sdk/store/CreateStoreTest.java
@@ -38,15 +38,15 @@ public class CreateStoreTest extends GenericTest {
   @Test
   public void shouldPostAndReturnNewStoreData() throws InterruptedException, MalformedURLException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "POST",
         "/stores",
-        token,
+        jwt,
         200,
         StoreFakeRR.createStoreFakeResponse,
         StoreFakeRR.createStoreFakeRequest);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final List<CardBrand> forbiddenCardBrands = new ArrayList<>();
     forbiddenCardBrands.add(CardBrand.JCB);
@@ -174,15 +174,15 @@ public class CreateStoreTest extends GenericTest {
   public void shouldPostAndReturnNewStoreDataWithNoConfiguration()
       throws IOException, UnivapayException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "POST",
         "/stores",
-        token,
+        jwt,
         200,
         StoreFakeRR.createStoreFakeEmptyResponse,
         StoreFakeRR.createStoreFakeEmptyRequest);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     StoreWithConfiguration response = univapay.createStore("A New Store").build().dispatch();
 

--- a/src/test/java/com/univapay/sdk/store/DeleteStoreTest.java
+++ b/src/test/java/com/univapay/sdk/store/DeleteStoreTest.java
@@ -15,10 +15,10 @@ public class DeleteStoreTest extends GenericTest {
   @Test
   public void shouldRequestDeletionOfStore() throws InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
-        "DELETE", "/stores/fbb48b8e-a443-45f7-9b7d-c278087f8060", token, 200, "{}");
+    mockRRGenerator.GenerateMockRequestResponseJWT(
+        "DELETE", "/stores/fbb48b8e-a443-45f7-9b7d-c278087f8060", jwt, 200, "{}");
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .deleteStore(new StoreId("fbb48b8e-a443-45f7-9b7d-c278087f8060"))

--- a/src/test/java/com/univapay/sdk/store/GetStoreTest.java
+++ b/src/test/java/com/univapay/sdk/store/GetStoreTest.java
@@ -20,14 +20,14 @@ public class GetStoreTest extends GenericTest {
   @Test
   public void shouldRequestAndReturnStoreInfo() throws InterruptedException, ParseException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/11e751a6-15b1-169c-8d58-47c3d241a399",
-        token,
+        jwt,
         200,
         StoreFakeRR.getStoreFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate = parseDate("2017-06-22T16:00:55.436116+09:00");
 

--- a/src/test/java/com/univapay/sdk/store/ListStoresTest.java
+++ b/src/test/java/com/univapay/sdk/store/ListStoresTest.java
@@ -21,10 +21,10 @@ public class ListStoresTest extends GenericTest {
   public void shouldRequestAndReturnListOfStoresWithoutQueryParams()
       throws InterruptedException, ParseException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
-        "GET", "/stores", token, 200, StoreFakeRR.listAllStoresFakeResponse);
+    mockRRGenerator.GenerateMockRequestResponseJWT(
+        "GET", "/stores", jwt, 200, StoreFakeRR.listAllStoresFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate = parseDate("2017-06-22T16:00:55.436116+09:00");
 
@@ -84,14 +84,14 @@ public class ListStoresTest extends GenericTest {
   public void shouldRequestAndReturnListOfStoresWithOptionalParams()
       throws InterruptedException, ParseException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores?search=New%20Store%204",
-        token,
+        jwt,
         200,
         StoreFakeRR.listAllStoresSearchParamFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate = parseDate("2017-06-22T16:00:55.436116+09:00");
 

--- a/src/test/java/com/univapay/sdk/store/UpdateStoreTest.java
+++ b/src/test/java/com/univapay/sdk/store/UpdateStoreTest.java
@@ -37,15 +37,15 @@ public class UpdateStoreTest extends GenericTest {
   public void shouldPostAndReturnUpdatedStoreInfo()
       throws InterruptedException, MalformedURLException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "PATCH",
         "/stores/11e751a6-15b1-169c-8d58-47c3d241a399",
-        token,
+        jwt,
         200,
         StoreFakeRR.updateStoreFakeResponse,
         StoreFakeRR.updateStoreFakeRequest);
 
-    UnivapaySDK sdk = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK sdk = createTestInstance(AuthType.JWT);
 
     final List<CardBrand> forbiddenCardBrands = new ArrayList<>();
     forbiddenCardBrands.add(CardBrand.JCB);
@@ -208,15 +208,15 @@ public class UpdateStoreTest extends GenericTest {
   public void shouldPostAndReturnUpdatedStoreInfoWithNoConfiguration()
       throws IOException, UnivapayException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "PATCH",
         "/stores/11e751a6-15b1-169c-8d58-47c3d241a399",
-        token,
+        jwt,
         200,
         StoreFakeRR.updateStoreFakeEmptyResponse,
         StoreFakeRR.updateStoreFakeEmptyRequest);
 
-    UnivapaySDK sdk = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK sdk = createTestInstance(AuthType.JWT);
 
     StoreWithConfiguration response =
         sdk.updateStore(new StoreId("11e751a6-15b1-169c-8d58-47c3d241a399"))

--- a/src/test/java/com/univapay/sdk/subscription/DeleteSubscriptionTest.java
+++ b/src/test/java/com/univapay/sdk/subscription/DeleteSubscriptionTest.java
@@ -16,14 +16,14 @@ public class DeleteSubscriptionTest extends GenericTest {
   @Test
   public void shouldRequestDeletionOfSubscription() throws InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "DELETE",
         "/stores/45facc11-efc8-4156-8ef3-e363a70a54c3/subscriptions/714498e7-5031-4d48-b2ac-9bad8a8a4141",
-        token,
+        jwt,
         200,
         "{}");
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .deleteSubscription(

--- a/src/test/java/com/univapay/sdk/subscription/GetSubscriptionPaymentTest.java
+++ b/src/test/java/com/univapay/sdk/subscription/GetSubscriptionPaymentTest.java
@@ -23,14 +23,14 @@ public class GetSubscriptionPaymentTest extends GenericTest {
   @Test
   public void shouldGetAPaymentForASubscription() throws Exception {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/11e82dbf-7e6a-d146-9423-03ae2c18d764/subscriptions/11e89925-9602-58f2-8f45-fb716a8fc34e/payments/11e89925-967d-1bd2-a831-43c06e016572",
-        token,
+        jwt,
         200,
         ChargesFakeRR.getPaymentFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     ScheduledPayment payment =
         univapay

--- a/src/test/java/com/univapay/sdk/subscription/GetSubscriptionTest.java
+++ b/src/test/java/com/univapay/sdk/subscription/GetSubscriptionTest.java
@@ -28,14 +28,14 @@ public class GetSubscriptionTest extends GenericTest {
   @Test
   public void shouldRequestAndReturnSubscriptionInfo() throws Exception {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/11e82dbf-7e6a-d146-9423-03ae2c18d764/subscriptions/11e897ac-8cc6-5178-aea8-b7d42ee9639f",
-        token,
+        jwt,
         200,
         ChargesFakeRR.getSubscriptionFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     FullSubscription response =
         univapay

--- a/src/test/java/com/univapay/sdk/subscription/ListPaymentChargesTest.java
+++ b/src/test/java/com/univapay/sdk/subscription/ListPaymentChargesTest.java
@@ -27,14 +27,14 @@ public class ListPaymentChargesTest extends GenericTest {
   public void shouldListPaymentcharges() throws Exception {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/11e82dbf-7e6a-d146-9423-03ae2c18d764/subscriptions/11e89932-7c5f-78c8-b747-27cf2f8ee9b4/payments/11e89932-7c6a-8376-b749-7b3852eeec56/charges",
-        token,
+        jwt,
         200,
         ChargesFakeRR.listChargesForPaymentFakeRequest);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     PaginatedList<Charge> charges =
         univapay

--- a/src/test/java/com/univapay/sdk/subscription/ListPaymentsTest.java
+++ b/src/test/java/com/univapay/sdk/subscription/ListPaymentsTest.java
@@ -24,14 +24,14 @@ public class ListPaymentsTest extends GenericTest {
   public void shouldListPaymentsForASubscription() throws Exception {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/11e82dbf-7e6a-d146-9423-03ae2c18d764/subscriptions/11e89932-7c5f-78c8-b747-27cf2f8ee9b4/payments",
-        token,
+        jwt,
         200,
         ChargesFakeRR.listPaymentsFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     PaginatedList<ScheduledPayment> payments =
         univapay

--- a/src/test/java/com/univapay/sdk/subscription/ListSubscriptionChargesTest.java
+++ b/src/test/java/com/univapay/sdk/subscription/ListSubscriptionChargesTest.java
@@ -23,15 +23,15 @@ public class ListSubscriptionChargesTest extends GenericTest {
   public void listsSubscriptionChargesSuccessfully() throws InterruptedException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/33fb1370-e930-11e6-8e89-07a500c3935d/subscriptions"
             + "/96fcbd50-e932-11e6-8f46-d79febd4479a/charges",
-        token,
+        jwt,
         200,
         ChargesFakeRR.listSubscriptionCharges);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .listSubscriptionCharges(

--- a/src/test/java/com/univapay/sdk/subscription/ListSubscriptionPaymentsTest.java
+++ b/src/test/java/com/univapay/sdk/subscription/ListSubscriptionPaymentsTest.java
@@ -25,15 +25,15 @@ public class ListSubscriptionPaymentsTest extends GenericTest {
   public void listsSubscriptionChargesSuccessfully() throws InterruptedException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/33fb1370-e930-11e6-8e89-07a500c3935d/subscriptions"
             + "/96fcbd50-e932-11e6-8f46-d79febd4479a/payments/96fcbd50-e932-11e6-8f46-d79febd4479a/charges",
-        token,
+        jwt,
         200,
         ChargesFakeRR.listSubscriptionCharges);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .listChargesForPayment(

--- a/src/test/java/com/univapay/sdk/subscription/ListSubscriptionsMerchantTest.java
+++ b/src/test/java/com/univapay/sdk/subscription/ListSubscriptionsMerchantTest.java
@@ -30,14 +30,10 @@ public class ListSubscriptionsMerchantTest extends GenericTest {
   public void shouldRequestAndReturnListOfSubscriptions()
       throws InterruptedException, ParseException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
-        "GET",
-        "/subscriptions",
-        token,
-        200,
-        ChargesFakeRR.listAllMerchantSubscriptionsFakeResponse);
+    mockRRGenerator.GenerateMockRequestResponseJWT(
+        "GET", "/subscriptions", jwt, 200, ChargesFakeRR.listAllMerchantSubscriptionsFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .listSubscriptions()

--- a/src/test/java/com/univapay/sdk/subscription/ListSubscriptionsTest.java
+++ b/src/test/java/com/univapay/sdk/subscription/ListSubscriptionsTest.java
@@ -30,14 +30,14 @@ public class ListSubscriptionsTest extends GenericTest {
   public void shouldRequestAndReturnListOfSubscriptions()
       throws InterruptedException, ParseException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/11e82dbf-7e6a-d146-9423-03ae2c18d764/subscriptions",
-        token,
+        jwt,
         200,
         ChargesFakeRR.listAllStoreSubscriptionsFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .listSubscriptions(new StoreId("11e82dbf-7e6a-d146-9423-03ae2c18d764"))

--- a/src/test/java/com/univapay/sdk/subscription/SimulateSubscriptionPlanTest.java
+++ b/src/test/java/com/univapay/sdk/subscription/SimulateSubscriptionPlanTest.java
@@ -40,15 +40,15 @@ public class SimulateSubscriptionPlanTest extends GenericTest {
   public void shouldRequestAPaymentsPlanSimulation() throws Exception {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "POST",
         "/subscriptions/simulate_plan",
-        token,
+        jwt,
         200,
         ChargesFakeRR.simulatePlanFakeResponse,
         ChargesFakeRR.simulatePlanFakeRequest);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     PaymentsPlan paymentsPlan =
         univapay
@@ -76,15 +76,15 @@ public class SimulateSubscriptionPlanTest extends GenericTest {
     StoreId storeId = new StoreId(UUID.randomUUID());
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "POST",
         "/stores/" + storeId.toString() + "/subscriptions/simulate_plan",
-        token,
+        jwt,
         200,
         "[]",
         ChargesFakeRR.simulatePlanFakeRequest);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .simulateSubscriptionPlan(

--- a/src/test/java/com/univapay/sdk/subscription/SubscriptionCompletionMonitorTest.java
+++ b/src/test/java/com/univapay/sdk/subscription/SubscriptionCompletionMonitorTest.java
@@ -27,14 +27,14 @@ public class SubscriptionCompletionMonitorTest extends GenericTest {
   public void shouldRequestAndReturnSubscriptionInfo()
       throws InterruptedException, UnivapayException, TimeoutException, IOException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/653ef5a3-73f2-408a-bac5-7058835f7700/subscriptions/425e88b7-b588-4247-80ee-0ea0caff1190?polling=true",
-        token,
+        jwt,
         200,
         ChargesFakeRR.getSubscriptionCompletedFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     ResourceMonitor<FullSubscription> monitor =
         univapay.subscriptionCompletionMonitor(
@@ -48,14 +48,14 @@ public class SubscriptionCompletionMonitorTest extends GenericTest {
   @Test
   public void shouldRequestAndReturnSubscriptionInfoAsync() throws InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/653ef5a3-73f2-408a-bac5-7058835f7700/subscriptions/425e88b7-b588-4247-80ee-0ea0caff1190?polling=true",
-        token,
+        jwt,
         200,
         ChargesFakeRR.getSubscriptionCompletedFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     ResourceMonitor<FullSubscription> monitor =
         univapay.subscriptionCompletionMonitor(

--- a/src/test/java/com/univapay/sdk/subscription/UpdateSubscriptionPaymentTest.java
+++ b/src/test/java/com/univapay/sdk/subscription/UpdateSubscriptionPaymentTest.java
@@ -16,15 +16,15 @@ public class UpdateSubscriptionPaymentTest extends GenericTest {
   public void shouldUpdateSubscriptionPaymentPaidStatus() throws Exception {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "PATCH",
         "/stores/11e82dbf-7e6a-d146-9423-03ae2c18d764/subscriptions/11e89925-9602-58f2-8f45-fb716a8fc34e/payments/11e89925-967d-1bd2-a831-43c06e016572",
-        token,
+        jwt,
         200,
         "{}",
         ChargesFakeRR.updatePaymentPaidStatusFakeRequest);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .updateScheduledPayment(

--- a/src/test/java/com/univapay/sdk/subscription/UpdateSubscriptionTest.java
+++ b/src/test/java/com/univapay/sdk/subscription/UpdateSubscriptionTest.java
@@ -26,10 +26,10 @@ public class UpdateSubscriptionTest extends GenericTest {
   @Test
   public void shouldPostAndReturnUpdatedSubscriptionInfo() throws Exception {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "PATCH",
         "/stores/11e821e9-806e-7a06-a00c-fb1ee377211d/subscriptions/11e821e9-8078-c3bc-851f-8b3cff59a635",
-        token,
+        jwt,
         200,
         "{}",
         ChargesFakeRR.updateSubscriptionFakeRequest);
@@ -43,7 +43,7 @@ public class UpdateSubscriptionTest extends GenericTest {
             true,
             3.141592F);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     TransactionTokenId transactionTokenId =
         new TransactionTokenId("7f5eecc8-3b38-4cec-86bb-644af74cb186");
@@ -73,15 +73,15 @@ public class UpdateSubscriptionTest extends GenericTest {
   public void shouldSerializeCorrectlyRequestsToRemoveInstallmentsPlan()
       throws UnivapayException, IOException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "PATCH",
         "/stores/11e821e9-806e-7a06-a00c-fb1ee377211d/subscriptions/11e821e9-8078-c3bc-851f-8b3cff59a635",
-        token,
+        jwt,
         200,
         "{}",
         ChargesFakeRR.removeInstallmentsPlanFakeRequest);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     TransactionTokenId transactionTokenId =
         new TransactionTokenId("7f5eecc8-3b38-4cec-86bb-644af74cb186");

--- a/src/test/java/com/univapay/sdk/transactiontoken/CreateTransactionTokenTest.java
+++ b/src/test/java/com/univapay/sdk/transactiontoken/CreateTransactionTokenTest.java
@@ -601,7 +601,7 @@ public class CreateTransactionTokenTest extends GenericTest {
     mockRRGenerator.GenerateMockRequestResponseJWT(
         "POST",
         "/tokens",
-        token,
+        jwt,
         200,
         StoreFakeRR.createTransactionTokenFakeResponse,
         StoreFakeRR.createTransactionTokenFakeRequest,
@@ -609,7 +609,7 @@ public class CreateTransactionTokenTest extends GenericTest {
 
     UnivapaySDK univapay =
         UnivapaySDK.create(
-            new AppJWTStrategy(token),
+            new AppJWTStrategy(jwt),
             new UnivapayDebugSettings()
                 .attachOrigin(origin)
                 .withEndpoint(TEST_ENDPOINT)

--- a/src/test/java/com/univapay/sdk/transactiontoken/DeleteTransactionTokenTest.java
+++ b/src/test/java/com/univapay/sdk/transactiontoken/DeleteTransactionTokenTest.java
@@ -15,14 +15,14 @@ public class DeleteTransactionTokenTest extends GenericTest {
   @Test
   public void shouldRequestDeletionOfTransactionToken() throws Exception {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "DELETE",
         "/stores/fbb48b8e-a443-45f7-9b7d-c278087f8060/tokens/004b391f-1c98-43f8-87de-28b21aaaca00",
-        token,
+        jwt,
         200,
         "{}");
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .deleteTransactionToken(

--- a/src/test/java/com/univapay/sdk/transactiontoken/GetTransactionTokenTest.java
+++ b/src/test/java/com/univapay/sdk/transactiontoken/GetTransactionTokenTest.java
@@ -31,14 +31,14 @@ public class GetTransactionTokenTest extends GenericTest {
   @Test
   public void shouldRequestAndReturnTransactionTokenInfo() throws InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/bf75472e-7f2d-4745-a66d-9b96ae031c7a/tokens/004b391f-1c98-43f8-87de-28b21aaaca00",
-        token,
+        jwt,
         200,
         StoreFakeRR.getTransactionTokenFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate = parseDate("2017-06-22T16:00:55.436116+09:00");
 

--- a/src/test/java/com/univapay/sdk/transfer/GetTransferTest.java
+++ b/src/test/java/com/univapay/sdk/transfer/GetTransferTest.java
@@ -28,14 +28,14 @@ public class GetTransferTest extends GenericTest {
   @Test
   public void shouldRequestAndReturnTransferData() throws InterruptedException, ParseException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/transfers/c179c19f-5ccc-4f66-9f79-1a9ed8466098",
-        token,
+        jwt,
         200,
         TransfersFakeRR.getTransferFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate =
         OffsetDateTime.parse("2017-11-01T16:00:55.436116+09:00", DateTimeFormatter.ISO_DATE_TIME);

--- a/src/test/java/com/univapay/sdk/transfer/ListTransfersTest.java
+++ b/src/test/java/com/univapay/sdk/transfer/ListTransfersTest.java
@@ -22,10 +22,10 @@ public class ListTransfersTest extends GenericTest {
   @Test
   public void shouldRequestAndReturnListOfTransfers() throws InterruptedException, ParseException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
-        "GET", "/transfers", token, 200, TransfersFakeRR.listAllTransfersFakeResponse);
+    mockRRGenerator.GenerateMockRequestResponseJWT(
+        "GET", "/transfers", jwt, 200, TransfersFakeRR.listAllTransfersFakeResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate =
         OffsetDateTime.parse("2017-11-01T16:00:55.436116+09:00", DateTimeFormatter.ISO_DATE_TIME);

--- a/src/test/java/com/univapay/sdk/utility/UtilityTest.java
+++ b/src/test/java/com/univapay/sdk/utility/UtilityTest.java
@@ -13,9 +13,9 @@ public class UtilityTest extends GenericTest {
   @Test
   public void shouldBeat() throws IOException, UnivapayException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse("GET", "/heartbeat", token, 200, "{}");
+    mockRRGenerator.GenerateMockRequestResponseJWT("GET", "/heartbeat", jwt, 200, "{}");
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay.beat().build().dispatch();
   }

--- a/src/test/java/com/univapay/sdk/utils/GenericTest.java
+++ b/src/test/java/com/univapay/sdk/utils/GenericTest.java
@@ -9,7 +9,6 @@ import com.univapay.sdk.UnivapaySDK;
 import com.univapay.sdk.models.common.auth.AppJWTStrategy;
 import com.univapay.sdk.models.common.auth.AppTokenStrategy;
 import com.univapay.sdk.models.common.auth.LoginJWTStrategy;
-import com.univapay.sdk.models.common.auth.LoginTokenStrategy;
 import com.univapay.sdk.settings.AbstractSDKSettings;
 import com.univapay.sdk.types.AuthType;
 import java.io.UnsupportedEncodingException;
@@ -21,8 +20,6 @@ import java.util.concurrent.CountDownLatch;
 import org.junit.ClassRule;
 
 public class GenericTest {
-  protected static String token = "YwNV4LUO4PAePUfDv56q";
-  protected static LoginTokenStrategy loginTokenStrategy = new LoginTokenStrategy(token);
   protected static String appToken = "ZGlHubxJvNuoyhGRtNsn";
   protected static String secret = "CegjVnqiga68l2tRlVp9";
   protected static AppTokenStrategy appTokenStrategyWithSecret =
@@ -63,13 +60,6 @@ public class GenericTest {
     UnivapaySDK sdk;
 
     switch (authType) {
-      case LOGIN_TOKEN:
-        {
-          {
-            sdk = UnivapaySDK.create(loginTokenStrategy, testSettings);
-          }
-        }
-        break;
       case APP_TOKEN:
         {
           sdk = UnivapaySDK.create(appTokenStrategyWithSecret, testSettings);

--- a/src/test/java/com/univapay/sdk/utils/MockRRGenerator.java
+++ b/src/test/java/com/univapay/sdk/utils/MockRRGenerator.java
@@ -83,55 +83,6 @@ public class MockRRGenerator implements MockServer {
     return stub;
   }
 
-  public void GenerateMockRequestResponse(String method, String path, String token, int status) {
-    MappingBuilder stub =
-        createStub(
-            RequestMethod.fromString(method),
-            path,
-            token,
-            status,
-            null,
-            null,
-            AuthType.LOGIN_TOKEN,
-            null);
-    stubFor(stub);
-  }
-
-  public void GenerateMockRequestResponse(
-      String method, String path, String token, int status, String responseBody) {
-    MappingBuilder stub =
-        createStub(
-            RequestMethod.fromString(method),
-            path,
-            token,
-            status,
-            new JsonMockContent(responseBody),
-            null,
-            AuthType.LOGIN_TOKEN,
-            null);
-    stubFor(stub);
-  }
-
-  public void GenerateMockRequestResponse(
-      String method,
-      String path,
-      String token,
-      int status,
-      String responseBody,
-      String requestBody) {
-    MappingBuilder stub =
-        createStub(
-            RequestMethod.fromString(method),
-            path,
-            token,
-            status,
-            new JsonMockContent(responseBody),
-            requestBody,
-            AuthType.LOGIN_TOKEN,
-            null);
-    stubFor(stub);
-  }
-
   public void GenerateMockRequestResponseJWT(
       String method,
       String path,
@@ -167,7 +118,7 @@ public class MockRRGenerator implements MockServer {
     stubFor(stub);
   }
 
-  public void GenerateMockRequestResponse(
+  public void GenerateMockRequestResponseJWT(
       String method, String path, String token, int status, PaginatedMock paginatedMock) {
     MappingBuilder stub =
         createStub(
@@ -177,7 +128,7 @@ public class MockRRGenerator implements MockServer {
             status,
             new JsonMockContent(paginatedMock.getPaginatedResponse(path)),
             null,
-            AuthType.LOGIN_TOKEN,
+            AuthType.JWT,
             null);
     stubFor(stub);
   }

--- a/src/test/java/com/univapay/sdk/utils/mockcontent/AuthenticationFakeRR.java
+++ b/src/test/java/com/univapay/sdk/utils/mockcontent/AuthenticationFakeRR.java
@@ -7,7 +7,6 @@ public class AuthenticationFakeRR {
   public static String getLogintokenFakeResponse =
       "{\n"
           + "\"jwt\": \"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJsb2dpbl90b2tlbiIsImV4cCI6MTUyMDQyMjU3MywiaWF0IjoxNTIwNDE4OTczLCJqdGkiOiIxMWU4MjFmMy01YmIxLTBmODYtOTcxZi0wMWRkOGYwOTFhN2QiLCJtZXJjaGFudF9pZCI6IjExZTgyMWJlLTY4ZDQtNzMwOC1iYjYwLWI3MmRhYzA4MTA5OCIsIm5hbWUiOiJSb290IEFkbWluIiwiZW1haWwiOiJyb290X2FkbWluQHVuaXZhcGF5LmNvbSIsImxhbmciOiJqYSIsImlwX2FkZHJlc3MiOiIwOjA6MDowOjA6MDowOjEiLCJhdWQiOiIxMWU4MjFiZS02NWY4LWMxZmMtYjdmNi1iYjQ4NzFiYmExN2EiLCJyb2xlcyI6WyJhZG1pbiJdfQ.iaypSYq2kM1iCsAhZiRIe8WiEiAkPWqRNX6KhcrT8fY\",\n"
-          + "\"token\": \"quqhrNtsUY0ypKPbgfeO\",\n"
           + "\"merchant_id\": \"65774989-5cbb-4790-9cb9-17f127059d2d\"\n"
           + "}";
 }

--- a/src/test/java/com/univapay/sdk/utils/paginationmock/PaginatedMockTest.java
+++ b/src/test/java/com/univapay/sdk/utils/paginationmock/PaginatedMockTest.java
@@ -20,10 +20,10 @@ public class PaginatedMockTest extends GenericTest {
   @Test
   public void shouldListNoOption() throws InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
-        "GET", "/stores", token, 200, new PaginatedMock(StoresMock.storesMock));
+    mockRRGenerator.GenerateMockRequestResponseJWT(
+        "GET", "/stores", jwt, 200, new PaginatedMock(StoresMock.storesMock));
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate =
         OffsetDateTime.parse("2018-02-27T17:00:43.476016+09:00", DateTimeFormatter.ISO_DATE_TIME);
@@ -66,14 +66,14 @@ public class PaginatedMockTest extends GenericTest {
   @Test
   public void shouldListLimit2DescCursor() throws InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores?limit=2&cursor_direction=desc&cursor=11e81b94-4f52-1398-8ab3-230675bcb38f",
-        token,
+        jwt,
         200,
         new PaginatedMock(StoresMock.storesMock));
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate =
         OffsetDateTime.parse("2018-02-27T17:00:43.476016+09:00", DateTimeFormatter.ISO_DATE_TIME);
@@ -114,14 +114,14 @@ public class PaginatedMockTest extends GenericTest {
   @Test
   public void shouldListLimit2Asc() throws InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores?limit=2&cursor_direction=asc&cursor=11e81b94-4f53-a5c8-8ab3-d75ea65c02fc",
-        token,
+        jwt,
         200,
         new PaginatedMock(StoresMock.storesMock));
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate =
         OffsetDateTime.parse("2018-02-27T17:00:43.476016+09:00", DateTimeFormatter.ISO_DATE_TIME);
@@ -162,14 +162,14 @@ public class PaginatedMockTest extends GenericTest {
   @Test
   public void shouldListLimit1HasMore() throws InterruptedException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores?limit=1&cursor_direction=asc&cursor=11e81b94-4f53-a5c8-8ab3-d75ea65c02fc",
-        token,
+        jwt,
         200,
         new PaginatedMock(StoresMock.storesMock));
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate =
         OffsetDateTime.parse("2018-02-27T17:00:43.476016+09:00", DateTimeFormatter.ISO_DATE_TIME);

--- a/src/test/java/com/univapay/sdk/webhook/CreateMerchantWebhookTest.java
+++ b/src/test/java/com/univapay/sdk/webhook/CreateMerchantWebhookTest.java
@@ -21,10 +21,10 @@ public class CreateMerchantWebhookTest extends GenericTest {
   @Test
   public void shouldPostAndReturnWebhookInfo() throws InterruptedException, IOException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
-        "POST", "/webhooks", token, 200, StoreFakeRR.createMerchantWebhookResponse);
+    mockRRGenerator.GenerateMockRequestResponseJWT(
+        "POST", "/webhooks", jwt, 200, StoreFakeRR.createMerchantWebhookResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
     final List<PaymentSystemEvent> triggers = new ArrayList<>();
     triggers.add(PaymentSystemEvent.CHARGE_FINISHED);
     triggers.add(PaymentSystemEvent.SUBSCRIPTION_SUSPENDED);

--- a/src/test/java/com/univapay/sdk/webhook/CreateWebhookTest.java
+++ b/src/test/java/com/univapay/sdk/webhook/CreateWebhookTest.java
@@ -22,14 +22,14 @@ public class CreateWebhookTest extends GenericTest {
   @Test
   public void shouldPostAndReturnWebhookInfo() throws InterruptedException, IOException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "POST",
         "/stores/f5cc70be-da82-4fad-affc-e79888189066/webhooks",
-        token,
+        jwt,
         200,
         StoreFakeRR.createStoreWebhookResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final List<PaymentSystemEvent> triggers = new ArrayList<>();
     triggers.add(PaymentSystemEvent.CHARGE_FINISHED);

--- a/src/test/java/com/univapay/sdk/webhook/DeleteMerchantWebhookTest.java
+++ b/src/test/java/com/univapay/sdk/webhook/DeleteMerchantWebhookTest.java
@@ -16,10 +16,10 @@ public class DeleteMerchantWebhookTest extends GenericTest {
   public void shouldRequestDeletionOfWebhook() throws InterruptedException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
-        "DELETE", "/webhooks/11e7a4e4-5a21-fc74-8205-17c780e6c7ee", token, 200, "{}");
+    mockRRGenerator.GenerateMockRequestResponseJWT(
+        "DELETE", "/webhooks/11e7a4e4-5a21-fc74-8205-17c780e6c7ee", jwt, 200, "{}");
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .deleteWebhook(new WebhookId("11e7a4e4-5a21-fc74-8205-17c780e6c7ee"))

--- a/src/test/java/com/univapay/sdk/webhook/DeleteWebhookTest.java
+++ b/src/test/java/com/univapay/sdk/webhook/DeleteWebhookTest.java
@@ -17,14 +17,14 @@ public class DeleteWebhookTest extends GenericTest {
   public void shouldRequestDeletionOfWebhook() throws InterruptedException {
 
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "DELETE",
         "/stores/f5cc70be-da82-4fad-affc-e79888189066/webhooks/7b934b64-9c82-433f-a4fe-13a54efc0fc2",
-        token,
+        jwt,
         200,
         "{}");
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .deleteWebhook(

--- a/src/test/java/com/univapay/sdk/webhook/GetMerchantWebhookTest.java
+++ b/src/test/java/com/univapay/sdk/webhook/GetMerchantWebhookTest.java
@@ -24,14 +24,14 @@ public class GetMerchantWebhookTest extends GenericTest {
   @Test
   public void shouldRequestAndReturnWebhookInfo() throws InterruptedException, ParseException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/webhooks/11e796c8-a853-8928-9665-a709cfc94f15",
-        token,
+        jwt,
         200,
         StoreFakeRR.getMerchantWebhookResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate =
         OffsetDateTime.parse("2017-09-11T08:10:21.000000+09:00", DateTimeFormatter.ISO_DATE_TIME);

--- a/src/test/java/com/univapay/sdk/webhook/GetWebhookTest.java
+++ b/src/test/java/com/univapay/sdk/webhook/GetWebhookTest.java
@@ -25,14 +25,14 @@ public class GetWebhookTest extends GenericTest {
   @Test
   public void shouldRequestAndReturnWebhookInfo() throws InterruptedException, ParseException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/8486dc98-9836-41dd-b598-bbf49d5bc861/webhooks/f3002de3-c076-4194-bef5-c88882e4f5fe",
-        token,
+        jwt,
         200,
         StoreFakeRR.getStoreWebhookResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate =
         OffsetDateTime.parse("2017-06-22T16:00:55.436116+09:00", DateTimeFormatter.ISO_DATE_TIME);

--- a/src/test/java/com/univapay/sdk/webhook/ListMerchantWebhooksTest.java
+++ b/src/test/java/com/univapay/sdk/webhook/ListMerchantWebhooksTest.java
@@ -21,10 +21,10 @@ public class ListMerchantWebhooksTest extends GenericTest {
   @Test
   public void shouldRequestAndReturnListOfWebhooks() throws InterruptedException, ParseException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
-        "GET", "/webhooks", token, 200, StoreFakeRR.listAllMerchantWebhooksResponse);
+    mockRRGenerator.GenerateMockRequestResponseJWT(
+        "GET", "/webhooks", jwt, 200, StoreFakeRR.listAllMerchantWebhooksResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate0 =
         OffsetDateTime.parse("2017-09-28T07:35:02.000000+09:00", DateTimeFormatter.ISO_DATE_TIME);

--- a/src/test/java/com/univapay/sdk/webhook/ListWebhooksTest.java
+++ b/src/test/java/com/univapay/sdk/webhook/ListWebhooksTest.java
@@ -22,14 +22,14 @@ public class ListWebhooksTest extends GenericTest {
   @Test
   public void shouldRequestAndReturnListOfWebhooks() throws InterruptedException, ParseException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "GET",
         "/stores/8486dc98-9836-41dd-b598-bbf49d5bc861/webhooks",
-        token,
+        jwt,
         200,
         StoreFakeRR.listAllStoreWebhooksResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final OffsetDateTime parsedDate =
         OffsetDateTime.parse("2017-06-22T16:00:55.436116+09:00", DateTimeFormatter.ISO_DATE_TIME);

--- a/src/test/java/com/univapay/sdk/webhook/UpdateMerchantWebhookTest.java
+++ b/src/test/java/com/univapay/sdk/webhook/UpdateMerchantWebhookTest.java
@@ -19,14 +19,14 @@ public class UpdateMerchantWebhookTest extends GenericTest {
   @Test
   public void shouldPostAndReturnUpdatedWebhookInfo() throws InterruptedException, IOException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "PATCH",
         "/webhooks/11e7a41f-8a04-9980-a983-c34a960d1344",
-        token,
+        jwt,
         200,
         StoreFakeRR.updateMerchantWebhookResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     final String WEBHOOK_URL = "http://www.webhook.com";
 

--- a/src/test/java/com/univapay/sdk/webhook/UpdateWebhookTest.java
+++ b/src/test/java/com/univapay/sdk/webhook/UpdateWebhookTest.java
@@ -20,14 +20,14 @@ public class UpdateWebhookTest extends GenericTest {
   @Test
   public void shouldPostAndReturnUpdatedWebhookInfo() throws InterruptedException, IOException {
     MockRRGenerator mockRRGenerator = new MockRRGenerator();
-    mockRRGenerator.GenerateMockRequestResponse(
+    mockRRGenerator.GenerateMockRequestResponseJWT(
         "PATCH",
         "/stores/f5cc70be-da82-4fad-affc-e79888189066/webhooks/7b934b64-9c82-433f-a4fe-13a54efc0fc2",
-        token,
+        jwt,
         200,
         StoreFakeRR.updateStoreWebhookResponse);
 
-    UnivapaySDK univapay = createTestInstance(AuthType.LOGIN_TOKEN);
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
 
     univapay
         .updateWebhook(


### PR DESCRIPTION
Remove the legacy token login strategy as the API wants to remove the field. Also update the tests to consistently use the JWT verification.

@andrezimmermann Seems that I can not add reviewers. Sorry for the inconvenience.