### PR TITLE
SDK now returns Cancelable when a using dispatch(Callback)

### DIFF
--- a/src/main/java/com/univapay/sdk/builders/Cancelable.java
+++ b/src/main/java/com/univapay/sdk/builders/Cancelable.java
@@ -1,0 +1,8 @@
+package com.univapay.sdk.builders;
+
+/** Handle to cancel a dispatched request that was invoked with a callback */
+public interface Cancelable {
+
+  /** Cancel the request as "best effort" basis */
+  void cancel();
+}

--- a/src/main/java/com/univapay/sdk/builders/Request.java
+++ b/src/main/java/com/univapay/sdk/builders/Request.java
@@ -13,8 +13,9 @@ public interface Request<E> {
    * (response/failure)
    *
    * @param callback to be executed
+   * @return a handle to cancel the dispatched request
    */
-  void dispatch(UnivapayCallback<E> callback);
+  Cancelable dispatch(UnivapayCallback<E> callback);
 
   E dispatch() throws IOException, UnivapayException, TooManyRequestsException;
 

--- a/src/main/java/com/univapay/sdk/builders/RetrofitRequestBuilder.java
+++ b/src/main/java/com/univapay/sdk/builders/RetrofitRequestBuilder.java
@@ -36,8 +36,8 @@ public abstract class RetrofitRequestBuilder<E extends UnivapayResponse, R>
   }
 
   @Override
-  public void dispatch(final UnivapayCallback<E> callback) {
-    build().dispatch(callback);
+  public Cancelable dispatch(final UnivapayCallback<E> callback) {
+    return build().dispatch(callback);
   }
 
   @Override

--- a/src/main/java/com/univapay/sdk/utils/UnivapayCallback.java
+++ b/src/main/java/com/univapay/sdk/utils/UnivapayCallback.java
@@ -4,4 +4,11 @@ public interface UnivapayCallback<T> {
   void getResponse(T response);
 
   void getFailure(Throwable error);
+
+  /**
+   * In case there was a cancel event, it is signalled downstream, unfortunately, there is no
+   * information whether this request was already in-flight or not, therefore treat this request as
+   * might have been successful, the cancel event are manually invoked
+   */
+  default void onCancel() {}
 }

--- a/src/main/java/com/univapay/sdk/utils/functions/UnivapayFunctions.java
+++ b/src/main/java/com/univapay/sdk/utils/functions/UnivapayFunctions.java
@@ -1,5 +1,6 @@
 package com.univapay.sdk.utils.functions;
 
+import com.univapay.sdk.builders.Cancelable;
 import com.univapay.sdk.builders.Request;
 import com.univapay.sdk.models.errors.TooManyRequestsException;
 import com.univapay.sdk.models.errors.UnivapayException;
@@ -29,9 +30,9 @@ public class UnivapayFunctions {
 
     return new Request<M2>() {
       @Override
-      public void dispatch(final UnivapayCallback<M2> callback) {
+      public Cancelable dispatch(final UnivapayCallback<M2> callback) {
 
-        firstRequest.dispatch(
+        return firstRequest.dispatch(
             new UnivapayCallback<M1>() {
               @Override
               public void getResponse(M1 response) {
@@ -81,18 +82,13 @@ public class UnivapayFunctions {
     };
   }
 
-  public static <M1, T1 extends Request<M1>, M2, T2 extends Request<M2>> Request<M2> compose(
-      final T1 firstRequest, final Function<M1, T2> onSuccess) {
-    return compose(firstRequest, onSuccess, null);
-  }
-
   public static <M1, T1 extends Request<M1>> Request<M1> retry(
       final T1 request, final ErrorHandler<T1> errorHandler) {
 
     return new Request<M1>() {
       @Override
-      public void dispatch(final UnivapayCallback<M1> callback) {
-        request.dispatch(
+      public Cancelable dispatch(final UnivapayCallback<M1> callback) {
+        return request.dispatch(
             new UnivapayCallback<M1>() {
               @Override
               public void getResponse(M1 response) {

--- a/src/test/java/com/univapay/sdk/builders/CancelableRequestTest.java
+++ b/src/test/java/com/univapay/sdk/builders/CancelableRequestTest.java
@@ -1,0 +1,74 @@
+package com.univapay.sdk.builders;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static org.junit.Assert.fail;
+
+import com.univapay.sdk.UnivapaySDK;
+import com.univapay.sdk.models.common.ChargeId;
+import com.univapay.sdk.models.common.StoreId;
+import com.univapay.sdk.models.response.charge.Charge;
+import com.univapay.sdk.types.AuthType;
+import com.univapay.sdk.utils.GenericTest;
+import com.univapay.sdk.utils.UnivapayCallback;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+
+public class CancelableRequestTest extends GenericTest {
+
+  @Test
+  public void shouldBeAbleToCancelSomeRequest() throws InterruptedException {
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
+
+    stubFor(
+        get(urlEqualTo(
+                "/stores/00000000-0000-0000-0000-000000000001/charges/00000000-0000-0000-0000-000000000002"))
+            .willReturn(aResponse().withFixedDelay(1000).withStatus(404)));
+
+    Request<Charge> request =
+        univapay
+            .getCharge(
+                new StoreId("00000000-0000-0000-0000-000000000001"),
+                new ChargeId("00000000-0000-0000-0000-000000000002"))
+            .build();
+
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    Cancelable cancelable =
+        request.dispatch(
+            new UnivapayCallback<Charge>() {
+              @Override
+              public void getResponse(Charge response) {
+                try {
+                  fail("Request was cancelled, therefore this should never execute");
+                } finally {
+                  latch.countDown();
+                }
+              }
+
+              @Override
+              public void getFailure(Throwable error) {
+                try {
+                  fail("Request was cancelled, therefore this should never execute");
+
+                } finally {
+                  latch.countDown();
+                }
+              }
+
+              @Override
+              public void onCancel() {
+                latch.countDown();
+              }
+            });
+
+    cancelable.cancel();
+
+    boolean successful = latch.await(10, TimeUnit.SECONDS);
+
+    if (!successful) {
+      fail("Request was cancelled, but the latch wasn't released (callback not invoked)");
+    }
+  }
+}

--- a/src/test/java/com/univapay/sdk/builders/RetrofitRequestBuilderTest.java
+++ b/src/test/java/com/univapay/sdk/builders/RetrofitRequestBuilderTest.java
@@ -52,15 +52,11 @@ public class RetrofitRequestBuilderTest extends GenericTest {
             new StoreId("00000000-0000-0000-0000-000000000001"),
             new ChargeId("00000000-0000-0000-0000-000000000002"));
 
-    try {
-      requestBuilder.build().dispatch();
-      fail("No exception thrown");
-    } catch (IOException e) {
-      e.printStackTrace();
-      fail();
-    } catch (UnivapayException e) {
-      assertEquals(404, e.getHttpStatusCode());
-    }
+    Request<Charge> builtRequest = requestBuilder.build();
+
+    UnivapayException exception = assertThrows(UnivapayException.class, builtRequest::dispatch);
+
+    assertEquals(404, exception.getHttpStatusCode());
   }
 
   @Test


### PR DESCRIPTION
Allow manually canceling requests if there is need to "fail fast" a long running request or prevent the `getResponse(T response)` from being invoked