### PR TITLE
Updates Wiremock to 2.32.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     api 'com.google.code.findbugs:jsr305:3.0.2'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.junit.contrib:junit-theories:5.0-alpha-3'
-    testImplementation 'com.github.tomakehurst:wiremock:2.27.2'
+    testImplementation 'com.github.tomakehurst:wiremock-jre8:2.32.0'
     testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
     testImplementation 'org.slf4j:slf4j-simple:2.0.0-alpha5'
     testImplementation 'com.google.guava:guava:31.0.1-jre'


### PR DESCRIPTION
Should close #221 

Wiremock uses 9.4.44.v20210927 and seems fine from the report
It is just used just for tests and not included as dependency from the resulting package, but thanks for reporting 😃 
