### PR TITLE
Added the OnlineBrand and MpmBrand to the CheckoutInfo response models

### DIFF
--- a/src/main/java/com/univapay/sdk/models/response/store/CheckoutFeatureSupport.java
+++ b/src/main/java/com/univapay/sdk/models/response/store/CheckoutFeatureSupport.java
@@ -3,20 +3,28 @@ package com.univapay.sdk.models.response.store;
 import com.google.gson.annotations.SerializedName;
 import com.univapay.sdk.types.CardBrand;
 import com.univapay.sdk.types.Country;
+import com.univapay.sdk.types.brand.OnlineBrand;
+import com.univapay.sdk.types.brand.QrMpmBrand;
 import java.util.Set;
 
 public class CheckoutFeatureSupport {
   @SerializedName("card_brand")
   private final CardBrand cardBrand;
 
+  @SerializedName("online_brand")
+  private final OnlineBrand onlineBrand;
+
+  @SerializedName("qr_code")
+  private final QrMpmBrand qrMpmBrand;
+
+  @SerializedName("dynamic_info")
+  private final Boolean dynamicInfo;
+
   @SerializedName("support_auth_capture")
   private final Boolean supportAuthCapture;
 
   @SerializedName("requires_full_name")
   private final Boolean requiresFullName;
-
-  @SerializedName("support_dynamic_descriptor")
-  private final Boolean supportsDynamicDescriptor;
 
   @SerializedName("requires_cvv")
   private final Boolean requiresCVV;
@@ -27,8 +35,94 @@ public class CheckoutFeatureSupport {
   @SerializedName("supported_currencies")
   private final Set<String> supportedCurrencies;
 
+  protected CheckoutFeatureSupport(
+      CardBrand cardBrand,
+      OnlineBrand onlineBrand,
+      QrMpmBrand qrMpmBrand,
+      Boolean dynamicInfo,
+      Boolean supportAuthCapture,
+      Boolean requiresFullName,
+      Boolean requiresCVV,
+      Set<Country> countriesAllowed,
+      Set<String> supportedCurrencies) {
+    this.cardBrand = cardBrand;
+    this.onlineBrand = onlineBrand;
+    this.qrMpmBrand = qrMpmBrand;
+    this.dynamicInfo = dynamicInfo;
+    this.supportAuthCapture = supportAuthCapture;
+    this.requiresFullName = requiresFullName;
+    this.requiresCVV = requiresCVV;
+    this.countriesAllowed = countriesAllowed;
+    this.supportedCurrencies = supportedCurrencies;
+  }
+
+  public CheckoutFeatureSupport(
+      CardBrand cardBrand,
+      Boolean supportAuthCapture,
+      Boolean requiresFullName,
+      Boolean requiresCVV,
+      Set<Country> countriesAllowed,
+      Set<String> supportedCurrencies,
+      Boolean dynamicInfo) {
+    this(
+        cardBrand,
+        null,
+        null,
+        dynamicInfo,
+        supportAuthCapture,
+        requiresFullName,
+        requiresCVV,
+        countriesAllowed,
+        supportedCurrencies);
+  }
+
+  public CheckoutFeatureSupport(
+      OnlineBrand onlineBrand,
+      Boolean supportAuthCapture,
+      Boolean requiresFullName,
+      Boolean requiresCVV,
+      Set<Country> countriesAllowed,
+      Set<String> supportedCurrencies,
+      Boolean dynamicInfo) {
+    this(
+        null,
+        onlineBrand,
+        null,
+        dynamicInfo,
+        supportAuthCapture,
+        requiresFullName,
+        requiresCVV,
+        countriesAllowed,
+        supportedCurrencies);
+  }
+
+  public CheckoutFeatureSupport(
+      QrMpmBrand qrMpmBrand,
+      Boolean supportAuthCapture,
+      Boolean requiresFullName,
+      Boolean supportsDynamicDescriptor,
+      Boolean requiresCVV,
+      Set<Country> countriesAllowed,
+      Set<String> supportedCurrencies,
+      Boolean dynamicInfo) {
+    this(
+        null,
+        null,
+        qrMpmBrand,
+        dynamicInfo,
+        supportAuthCapture,
+        requiresFullName,
+        requiresCVV,
+        countriesAllowed,
+        supportedCurrencies);
+  }
+
   public CardBrand getCardBrand() {
     return cardBrand;
+  }
+
+  public OnlineBrand getOnlineBrand() {
+    return onlineBrand;
   }
 
   public Boolean getSupportAuthCapture() {
@@ -37,10 +131,6 @@ public class CheckoutFeatureSupport {
 
   public Boolean getRequiresFullName() {
     return requiresFullName;
-  }
-
-  public Boolean getSupportsDynamicDescriptor() {
-    return supportsDynamicDescriptor;
   }
 
   public Boolean getRequiresCVV() {
@@ -55,21 +145,7 @@ public class CheckoutFeatureSupport {
     return supportedCurrencies;
   }
 
-  // Not to be manually created
-  public CheckoutFeatureSupport(
-      CardBrand cardBrand,
-      Boolean supportAuthCapture,
-      Boolean requiresFullName,
-      Boolean supportsDynamicDescriptor,
-      Boolean requiresCVV,
-      Set<Country> countriesAllowed,
-      Set<String> supportedCurrencies) {
-    this.cardBrand = cardBrand;
-    this.supportAuthCapture = supportAuthCapture;
-    this.requiresFullName = requiresFullName;
-    this.supportsDynamicDescriptor = supportsDynamicDescriptor;
-    this.requiresCVV = requiresCVV;
-    this.countriesAllowed = countriesAllowed;
-    this.supportedCurrencies = supportedCurrencies;
+  public QrMpmBrand getQrMpmBrand() {
+    return qrMpmBrand;
   }
 }

--- a/src/test/resources/responses/checkoutInfo/get-checkout-info.json
+++ b/src/test/resources/responses/checkoutInfo/get-checkout-info.json
@@ -60,7 +60,8 @@
   },
   "recurring_card_charge_cvv_confirmation": {
     "enabled": true,
-    "threshold": [  {
+    "threshold": [
+      {
         "amount": 10000,
         "currency": "JPY"
       }
@@ -82,9 +83,7 @@
       "requires_full_name": false,
       "requires_cvv": false,
       "countries_allowed": null,
-      "supported_currencies": [
-        "JPY"
-      ]
+      "supported_currencies": null
     },
     {
       "online_brand": "dana",
@@ -93,9 +92,7 @@
       "requires_full_name": false,
       "requires_cvv": false,
       "countries_allowed": null,
-      "supported_currencies": [
-        "JPY"
-      ]
+      "supported_currencies": null
     },
     {
       "online_brand": "connect_wallet",
@@ -104,9 +101,7 @@
       "requires_full_name": false,
       "requires_cvv": false,
       "countries_allowed": null,
-      "supported_currencies": [
-        "JPY"
-      ]
+      "supported_currencies": null
     },
     {
       "online_brand": "truemoney",
@@ -115,9 +110,7 @@
       "requires_full_name": false,
       "requires_cvv": false,
       "countries_allowed": null,
-      "supported_currencies": [
-        "JPY"
-      ]
+      "supported_currencies": null
     },
     {
       "online_brand": "alipay_hk",
@@ -126,9 +119,7 @@
       "requires_full_name": false,
       "requires_cvv": false,
       "countries_allowed": null,
-      "supported_currencies": [
-        "JPY"
-      ]
+      "supported_currencies": null
     },
     {
       "online_brand": "kakaopay",
@@ -137,9 +128,7 @@
       "requires_full_name": false,
       "requires_cvv": false,
       "countries_allowed": null,
-      "supported_currencies": [
-        "JPY"
-      ]
+      "supported_currencies": null
     },
     {
       "online_brand": "gcash",
@@ -148,9 +137,7 @@
       "requires_full_name": false,
       "requires_cvv": false,
       "countries_allowed": null,
-      "supported_currencies": [
-        "JPY"
-      ]
+      "supported_currencies": null
     },
     {
       "online_brand": "tng",
@@ -159,15 +146,12 @@
       "requires_full_name": false,
       "requires_cvv": false,
       "countries_allowed": null,
-      "supported_currencies": [
-        "JPY"
-      ]
+      "supported_currencies": null
     },
     {
       "card_brand": "maestro",
       "support_auth_capture": true,
       "requires_full_name": true,
-      "support_dynamic_descriptor": true,
       "requires_cvv": true,
       "countries_allowed": [
         "TW"
@@ -180,13 +164,11 @@
       "card_brand": "american_express",
       "support_auth_capture": true,
       "requires_full_name": false,
-      "support_dynamic_descriptor": true,
       "requires_cvv": false,
       "countries_allowed": null,
       "supported_currencies": [
         "JPY"
       ]
     }
-
   ]
 }


### PR DESCRIPTION

Added the `qr_brand` and `online_brand` for the CheckoutInfo response models

Also removed the `supports_dynamic_descriptor` fields, been a while since this was removed from the API response 🤔 

Closes #236 