### PR TITLE
Map JsonParseException as UnivapayException during Server Error

### DIFF
--- a/src/main/java/com/univapay/sdk/builders/RetrofitRequestCaller.java
+++ b/src/main/java/com/univapay/sdk/builders/RetrofitRequestCaller.java
@@ -1,5 +1,6 @@
 package com.univapay.sdk.builders;
 
+import com.google.gson.JsonParseException;
 import com.univapay.sdk.constants.UnivapayConstants;
 import com.univapay.sdk.models.errors.TooManyRequestsException;
 import com.univapay.sdk.models.errors.UnivapayErrorBody;
@@ -134,9 +135,9 @@ public class RetrofitRequestCaller<E extends UnivapayResponse> implements Reques
             Optional.of(errorBody)
                 .flatMap(
                     value -> {
-                      try {
+                      try { // {code:null, status:null, details:null}
                         return Optional.ofNullable(this.errorConverter.convert(errorBody));
-                      } catch (IOException e) {
+                      } catch (IOException | JsonParseException e) {
                         return Optional.empty();
                       }
                     })

--- a/src/test/java/com/univapay/sdk/errors/ValidationErrorsTest.java
+++ b/src/test/java/com/univapay/sdk/errors/ValidationErrorsTest.java
@@ -4,12 +4,18 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import com.univapay.sdk.UnivapaySDK;
+import com.univapay.sdk.models.common.QrScanData;
 import com.univapay.sdk.models.errors.UnivapayException;
+import com.univapay.sdk.models.response.transactiontoken.TransactionTokenWithData;
 import com.univapay.sdk.types.AuthType;
+import com.univapay.sdk.types.TransactionTokenType;
 import com.univapay.sdk.utils.GenericTest;
 import com.univapay.sdk.utils.MockRRGenerator;
+import com.univapay.sdk.utils.UnivapayCallback;
 import com.univapay.sdk.utils.mockcontent.ErrorsFakeRR;
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 public class ValidationErrorsTest extends GenericTest {
@@ -56,5 +62,74 @@ public class ValidationErrorsTest extends GenericTest {
       assertNull(e.getBody());
       assertEquals(e.getHttpStatusCode(), 401);
     }
+  }
+
+  @Test
+  public void shouldHandleAnEmptyBody() throws Exception {
+    MockRRGenerator mockRRGenerator = new MockRRGenerator();
+    mockRRGenerator.GenerateMockRequestResponseJWT("GET", "/stores", null, 500, "");
+
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
+    try {
+      univapay.listStores().build().dispatch();
+    } catch (UnivapayException e) {
+      assertNull(e.getBody());
+      assertEquals(e.getHttpStatusCode(), 500);
+    }
+  }
+
+  @Test
+  public void shouldHandleAnEmptyBodyWhenCreatingToken() throws Exception {
+    MockRRGenerator mockRRGenerator = new MockRRGenerator();
+    mockRRGenerator.GenerateMockRequestResponseJWT("POST", "/tokens", null, 500, "\"\"");
+
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
+
+    UnivapayException exception =
+        assertThrows(
+            UnivapayException.class,
+            () ->
+                univapay
+                    .createTransactionToken(
+                        new QrScanData("TEST QR"), TransactionTokenType.ONE_TIME)
+                    .dispatch());
+
+    assertNull(exception.getBody());
+    assertEquals(exception.getHttpStatusCode(), 500);
+  }
+
+  @Test
+  public void shouldHandleAnEmptyBodyWhenCreatingTokenAsync() throws Exception {
+    MockRRGenerator mockRRGenerator = new MockRRGenerator();
+    mockRRGenerator.GenerateMockRequestResponseJWT("POST", "/tokens", null, 500, "\"\"");
+
+    UnivapaySDK univapay = createTestInstance(AuthType.JWT);
+
+    CompletableFuture<UnivapayException> execution = new CompletableFuture<>();
+
+    univapay
+        .createTransactionToken(new QrScanData("TEST QR"), TransactionTokenType.ONE_TIME)
+        .dispatch(
+            new UnivapayCallback<TransactionTokenWithData>() {
+              @Override
+              public void getResponse(TransactionTokenWithData response) {
+                execution.completeExceptionally(new AssertionError("Should never be parse-able"));
+              }
+
+              @Override
+              public void getFailure(Throwable error) {
+                if (error instanceof UnivapayException) {
+                  execution.complete((UnivapayException) error);
+                } else {
+                  execution.completeExceptionally(
+                      new AssertionError("Must be UnivapayException, but was ", error));
+                }
+              }
+            });
+
+    UnivapayException exception = execution.get(10, TimeUnit.SECONDS);
+
+    assertNull(exception.getBody());
+    assertEquals(exception.getHttpStatusCode(), 500);
   }
 }


### PR DESCRIPTION
Is possible that the Univapay API might return 5xx.
There was already some code to convert invalid body to UnivapayException. 
Make sure now that the JsonParseException is also caught and converted to UnivapayException
