### PR TITLE
CreditCard - Change CVV to String

### DIFF
--- a/src/main/java/com/univapay/sdk/models/common/CreditCard.java
+++ b/src/main/java/com/univapay/sdk/models/common/CreditCard.java
@@ -7,44 +7,57 @@ import com.univapay.sdk.models.response.transactiontoken.PhoneNumber;
 import com.univapay.sdk.types.CardBrand;
 import com.univapay.sdk.types.Country;
 import com.univapay.sdk.types.PaymentTypeName;
+import lombok.Getter;
 
 public class CreditCard implements PaymentData {
+  @Getter
   @SerializedName("cardholder")
-  private String cardholder;
+  private final String cardholder;
 
+  @Getter
   @SerializedName("card_number")
-  private String cardNumber;
+  private final String cardNumber;
 
+  @Getter
   @SerializedName("exp_month")
-  private int expMonth;
+  private final int expMonth;
 
+  @Getter
   @SerializedName("exp_year")
-  private int expYear;
+  private final int expYear;
 
+  @Getter
   @SerializedName("cvv")
-  private Integer cvv;
+  private final String cvv;
 
+  @Getter
   @SerializedName("line1")
   private String line1;
 
+  @Getter
   @SerializedName("line2")
   private String line2;
 
+  @Getter
   @SerializedName("state")
   private String state;
 
+  @Getter
   @SerializedName("city")
   private String city;
 
   @SerializedName("country")
   private Country country;
 
+  @Getter
   @SerializedName("zip")
   private String postalCode;
 
+  @Getter
   @SerializedName("phone_number")
   private PhoneNumber phoneNumber;
 
+  @Getter
   @SerializedName("cvv_authorize")
   private CvvAuthorizationEnable cvvAuthorize;
 
@@ -99,67 +112,19 @@ public class CreditCard implements PaymentData {
     return this;
   }
 
-  private transient CardBrand cardType;
+  @Getter private final transient CardBrand cardType;
 
   public CreditCard(String cardholder, String cardNumber, int expMonth, int expYear) {
     this(cardholder, cardNumber, expMonth, expYear, null);
   }
 
-  public CreditCard(String cardholder, String cardNumber, int expMonth, int expYear, Integer cvv) {
+  public CreditCard(String cardholder, String cardNumber, int expMonth, int expYear, String cvv) {
     this.cardholder = cardholder;
     this.cardNumber = cardNumber;
     this.expMonth = expMonth;
     this.expYear = expYear;
     this.cvv = cvv;
     this.cardType = CardBrand.forCardNumber(cardNumber);
-  }
-
-  public String getCardholder() {
-    return cardholder;
-  }
-
-  public String getCardNumber() {
-    return cardNumber;
-  }
-
-  public int getExpMonth() {
-    return expMonth;
-  }
-
-  public int getExpYear() {
-    return expYear;
-  }
-
-  public Integer getCvv() {
-    return cvv;
-  }
-
-  public CardBrand getCardType() {
-    return cardType;
-  }
-
-  public String getState() {
-    return state;
-  }
-
-  public String getCity() {
-    return city;
-  }
-
-  public String getLine1() {
-    return line1;
-  }
-
-  public String getLine2() {
-    return line2;
-  }
-
-  public String getPostalCode() {
-    return postalCode;
-  }
-
-  public PhoneNumber getPhoneNumber() {
-    return phoneNumber;
   }
 
   public boolean validateDate() {
@@ -177,10 +142,6 @@ public class CreditCard implements PaymentData {
   @Override
   public PaymentTypeName getPaymentType() {
     return PaymentTypeName.CARD;
-  }
-
-  public CvvAuthorizationEnable getCvvAuthorize() {
-    return cvvAuthorize;
   }
 
   public CreditCard withCvvAuthorization(boolean enabled) {

--- a/src/test/java/com/univapay/sdk/transactiontoken/CreateTransactionTokenTest.java
+++ b/src/test/java/com/univapay/sdk/transactiontoken/CreateTransactionTokenTest.java
@@ -53,7 +53,7 @@ public class CreateTransactionTokenTest extends GenericTest {
     univapay
         .createTransactionToken(
             "some@email.com",
-            new CreditCard("full name", "4556137309615276", 12, 2018, 599)
+            new CreditCard("full name", "4556137309615276", 12, 2018, "599")
                 .addAddress(Country.JAPAN, null, "Tokyo", "somewhere", null, "111-1111"),
             TransactionTokenType.ONE_TIME)
         .withMetadata(requestMetadata)
@@ -103,7 +103,7 @@ public class CreateTransactionTokenTest extends GenericTest {
     UnivapaySDK univapay = createTestInstance(AuthType.APP_TOKEN);
     return univapay.createTransactionToken(
         "some@email.com",
-        new CreditCard("full name", "4556137309615276", 12, 2018, 599)
+        new CreditCard("full name", "4556137309615276", 12, 2018, "599")
             .addAddress(Country.JAPAN, null, "Tokyo", "somewhere", null, "111-1111"),
         TransactionTokenType.ONE_TIME);
   }
@@ -267,7 +267,7 @@ public class CreateTransactionTokenTest extends GenericTest {
     univapay
         .createTransactionToken(
             "some@email.com",
-            new CreditCard("full name", "4556137309615276", 12, 2018, 599)
+            new CreditCard("full name", "4556137309615276", 12, 2018, "599")
                 .addAddress(Country.JAPAN, null, "Tokyo", "somewhere", null, "111-1111"),
             TransactionTokenType.RECURRING)
         .withUsageLimit(RecurringTokenInterval.WEEKLY)
@@ -524,7 +524,7 @@ public class CreateTransactionTokenTest extends GenericTest {
     univapay
         .createTransactionToken(
             "some@email.com",
-            new CreditCard("full name", "4556137309615276", 12, 2018, 599)
+            new CreditCard("full name", "4556137309615276", 12, 2018, "599")
                 .addAddress("JP", null, "Tokyo", "somewhere", null, "111-1111"),
             TransactionTokenType.ONE_TIME)
         .withMetadata(requestMetadata)
@@ -568,7 +568,7 @@ public class CreateTransactionTokenTest extends GenericTest {
           univapay
               .createTransactionToken(
                   "some@email.com",
-                  new CreditCard("full name", "4556137309615276", 12, 2018, 599)
+                  new CreditCard("full name", "4556137309615276", 12, 2018, "599")
                       .addAddress(Country.JAPAN, null, "Tokyo", "somewhere", null, "111-1111"),
                   TransactionTokenType.ONE_TIME)
               .withMetadata(requestMetadata)
@@ -613,7 +613,7 @@ public class CreateTransactionTokenTest extends GenericTest {
         univapay
             .createTransactionToken(
                 "some@email.com",
-                new CreditCard("full name", "4556137309615276", 12, 2018, 599)
+                new CreditCard("full name", "4556137309615276", 12, 2018, "599")
                     .addAddress(Country.JAPAN, null, "Tokyo", "somewhere", null, "111-1111"),
                 TransactionTokenType.ONE_TIME)
             .withMetadata(metadata)
@@ -677,7 +677,7 @@ public class CreateTransactionTokenTest extends GenericTest {
         univapay
             .createTransactionToken(
                 "some@email.com",
-                new CreditCard("full name", "4556137309615276", 12, 2018, 599)
+                new CreditCard("full name", "4556137309615276", 12, 2018, "599")
                     .addAddress(Country.JAPAN, null, "Tokyo", "somewhere", null, "111-1111"),
                 TransactionTokenType.ONE_TIME)
             .withMetadata(requestMetadata)

--- a/src/test/java/com/univapay/sdk/utils/GenericTest.java
+++ b/src/test/java/com/univapay/sdk/utils/GenericTest.java
@@ -17,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.concurrent.CountDownLatch;
+import org.junit.After;
 import org.junit.ClassRule;
 
 public class GenericTest {
@@ -53,6 +54,11 @@ public class GenericTest {
 
   protected String urlEncode(String s) throws UnsupportedEncodingException {
     return URLEncoder.encode(s, StandardCharsets.UTF_8.name());
+  }
+
+  @After
+  public void afterEach() {
+    wireMockRule.resetAll();
   }
 
   protected static UnivapaySDK createTestInstance(AuthType authType) {
@@ -100,15 +106,13 @@ public class GenericTest {
 
     @Override
     public void getResponse(T response) {
-
       notifyCall();
     }
 
     @Override
     public void getFailure(Throwable error) {
-      System.out.println(error);
-      fail();
       notifyCall();
+      fail();
     }
   }
 }

--- a/src/test/java/com/univapay/sdk/utils/mockcontent/StoreFakeRR.java
+++ b/src/test/java/com/univapay/sdk/utils/mockcontent/StoreFakeRR.java
@@ -343,26 +343,7 @@ public class StoreFakeRR {
           + "}";
 
   public static String createTransactionTokenForCustomerRequest =
-      "{\n"
-          + "  \"payment_type\" : \"card\",\n"
-          + "  \"email\" : \"some@email.com\",\n"
-          + "  \"type\" : \"one_time\",\n"
-          + "  \"metadata\" : {\n"
-          + "    \"float\" : \"10.3\",\n"
-          + "    \"univapay-customer-id\" : \"7680e246-2d10-42bf-8bbb-2230e1ed712c\"\n"
-          + "  },\n"
-          + "  \"data\" : {\n"
-          + "    \"cardholder\" : \"full name\",\n"
-          + "    \"card_number\" : \"4556137309615276\",\n"
-          + "    \"exp_month\" : 12,\n"
-          + "    \"exp_year\" : 2018,\n"
-          + "    \"cvv\" : 599,\n"
-          + "    \"line1\" : \"somewhere\",\n"
-          + "    \"city\" : \"Tokyo\",\n"
-          + "    \"country\" : \"JP\",\n"
-          + "    \"zip\" : \"111-1111\"\n"
-          + "  }\n"
-          + "}";
+      JsonLoader.loadJson("requests/transactiontoken/post-card-with-customer-id.json");
 
   public static String createTransactionTokenForCustomerResponse =
       "{"
@@ -397,7 +378,7 @@ public class StoreFakeRR {
           + "}";
 
   public static String createTransactionTokenFakeRequest =
-      "{\"payment_type\":\"card\",\"email\":\"some@email.com\",\"type\":\"one_time\",\"metadata\":{\"float\":\"10.3\"},\"use_confirmation\": true,\"data\":{\"cardholder\":\"full name\",\"card_number\":\"4556137309615276\",\"exp_month\":12,\"exp_year\":2018,\"cvv\":599,\"line1\":\"somewhere\",\"city\":\"Tokyo\",\"country\":\"JP\",\"zip\":\"111-1111\"}}";
+      "{\"payment_type\":\"card\",\"email\":\"some@email.com\",\"type\":\"one_time\",\"metadata\":{\"float\":\"10.3\"},\"use_confirmation\": true,\"data\":{\"cardholder\":\"full name\",\"card_number\":\"4556137309615276\",\"exp_month\":12,\"exp_year\":2018,\"cvv\":\"599\",\"line1\":\"somewhere\",\"city\":\"Tokyo\",\"country\":\"JP\",\"zip\":\"111-1111\"}}";
 
   public static String createTransactionTokenWithoutCVVFakeRequest =
       "{\"payment_type\":\"card\",\"email\":\"some@email.com\",\"type\":\"one_time\",\"metadata\" : { },\"data\":{\"cardholder\":\"full name\",\"card_number\":\"4556137309615276\",\"exp_month\":12,\"exp_year\":2018,\"line1\":\"somewhere\",\"city\":\"Tokyo\",\"country\":\"JP\",\"zip\":\"111-1111\"}}";

--- a/src/test/resources/requests/transactiontoken/post-card-with-customer-id.json
+++ b/src/test/resources/requests/transactiontoken/post-card-with-customer-id.json
@@ -3,10 +3,9 @@
   "email": "some@email.com",
   "type": "one_time",
   "metadata": {
-    "float": "10.3"
+    "float": "10.3",
+    "univapay-customer-id": "7680e246-2d10-42bf-8bbb-2230e1ed712c"
   },
-  "use_confirmation": true,
-  "ip_address": "172.1.11.123",
   "data": {
     "cardholder": "full name",
     "card_number": "4556137309615276",
@@ -19,3 +18,4 @@
     "zip": "111-1111"
   }
 }
+


### PR DESCRIPTION
This is a simple type change, from Integer to String.

This was mainly changed at the backend to allow sending `0123`, which would is different than `123`

This would close #370.



