### PR TITLE
UnivapayException - Add message with Univapay Errors

### DIFF
--- a/src/main/java/com/univapay/sdk/models/errors/UnivapayErrorBody.java
+++ b/src/main/java/com/univapay/sdk/models/errors/UnivapayErrorBody.java
@@ -2,7 +2,9 @@ package com.univapay.sdk.models.errors;
 
 import com.google.gson.annotations.SerializedName;
 import java.util.List;
+import lombok.Getter;
 
+@Getter
 public class UnivapayErrorBody {
   @SerializedName("status")
   private String status;
@@ -19,18 +21,6 @@ public class UnivapayErrorBody {
     this.status = status;
     this.code = code;
     this.errors = errors;
-  }
-
-  public String getStatus() {
-    return status;
-  }
-
-  public String getCode() {
-    return code;
-  }
-
-  public List<DetailedError> getErrors() {
-    return errors;
   }
 
   @Override

--- a/src/main/java/com/univapay/sdk/models/errors/UnivapayException.java
+++ b/src/main/java/com/univapay/sdk/models/errors/UnivapayException.java
@@ -1,6 +1,9 @@
 package com.univapay.sdk.models.errors;
 
+import lombok.Getter;
+
 /** Exceptions that result from errors returned by the Univapay API. */
+@Getter
 public class UnivapayException extends Exception {
 
   final int httpStatusCode;
@@ -13,23 +16,9 @@ public class UnivapayException extends Exception {
     this.body = body;
   }
 
-  public int getHttpStatusCode() {
-    return httpStatusCode;
-  }
-
-  public String getHttpStatusMessage() {
-    return httpStatusMessage;
-  }
-
-  public UnivapayErrorBody getBody() {
-    return body;
-  }
-
   @Override
-  public String toString() {
-    return getClass().getName()
-        + "{ "
-        + "HTTPStatus: "
+  public String getMessage() {
+    return "{HTTPStatus: "
         + httpStatusCode
         + " "
         + httpStatusMessage
@@ -37,5 +26,10 @@ public class UnivapayException extends Exception {
         + "UnivapayError: "
         + (body != null ? body.toString() : "null")
         + "}";
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getName() + " " + getMessage();
   }
 }

--- a/src/test/java/com/univapay/sdk/utils/mockcontent/ErrorsFakeRR.java
+++ b/src/test/java/com/univapay/sdk/utils/mockcontent/ErrorsFakeRR.java
@@ -2,17 +2,13 @@ package com.univapay.sdk.utils.mockcontent;
 
 public class ErrorsFakeRR {
   public static String invalidFormatFakeRequest =
-      "{\n" + "  \"email\": \"newaccount\",\n" + "  \"password\": \"c\"\n" + "}";
+      "{\n" + "  \"email\": \"test@univapay.com\",\n" + "  \"password\": \"c\"\n" + "}";
 
   public static String invalidFormatFakeResponse =
       "{\n"
           + "  \"status\": \"error\",\n"
           + "  \"code\": \"VALIDATION_ERROR\",\n"
           + "  \"errors\": [\n"
-          + "    {\n"
-          + "      \"field\": \"email\",\n"
-          + "      \"reason\": \"INVALID_FORMAT_EMAIL\"\n"
-          + "    },\n"
           + "    {\n"
           + "      \"field\": \"password\",\n"
           + "      \"reason\": \"INVALID_FORMAT_LENGTH\"\n"


### PR DESCRIPTION
An albeit small, but overdue, refactor to the `UnivapayException`, sf4j ignores the `toString` and uses `message`, leading to unhelpful log messages.

This PR addresses that generating the message field for `UnivapayException`